### PR TITLE
Changed Client Type

### DIFF
--- a/src/main/java/net/krotscheck/features/database/entity/Client.java
+++ b/src/main/java/net/krotscheck/features/database/entity/Client.java
@@ -88,7 +88,7 @@ public final class Client extends AbstractEntity {
      */
     @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)
-    private ClientType type = ClientType.Public;
+    private ClientType type = ClientType.AuthorizationGrant;
 
     /**
      * A client secret, indicating a password which must be provided to the

--- a/src/main/java/net/krotscheck/features/database/entity/ClientType.java
+++ b/src/main/java/net/krotscheck/features/database/entity/ClientType.java
@@ -21,19 +21,48 @@ package net.krotscheck.features.database.entity;
  * Different kinds of client types. See OAuth Specification
  *
  * @author Michael Krotscheck
- * @see <a href="https://tools.ietf.org/html/rfc6749#section-2.1">https://tools.ietf.org/html/rfc6749#section-2.1</a>
+ * @see <a href="https://tools.ietf.org/html/rfc6749#section-4">https://tools.ietf.org/html/rfc6749#section-4</a>
  */
 public enum ClientType {
 
     /**
-     * A Confidential client, such as a server application - anything that can
-     * keep its credentials reasonably secure.
+     * A Confidential client, such as a server-based web application - which
+     * uses the authorization grant flow described in section 4.1 in the OAuth2
+     * Specification. The use case met is a server-based web application
+     * which is permitted to make API calls to the authorization server on
+     * behalf of the user.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.1">https://tools.ietf.org/html/rfc6749#section-4.1</a>
      */
-    Confidential,
+    AuthorizationGrant,
 
     /**
-     * A public client, such as a mobile application or a web application -
-     * anything where the credentials are not secure, or public.
+     * A Public client, such as a browser javascript application, which uses
+     * the Implicit grant flow described in section 4.2 of the OAuth2
+     * Specification.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.2">https://tools.ietf.org/html/rfc6749#section-4.2</a>
      */
-    Public
+    Implicit,
+
+    /**
+     * A confidential client, which attempts to authenticate using the
+     * username and password of an existing account. Described in section 4.3
+     * of the OAuth2 Specification. This is intended to be a migratory
+     * method, and should be used to exchange actual user credentials for an
+     * auth token.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.3">https://tools.ietf.org/html/rfc6749#section-4.3</a>
+     */
+    OwnerCredentials,
+
+    /**
+     * A confidential client, which attempts to authenticate itself using a
+     * client-specific userid and password. This is often used in cases where
+     * your server application needs to access resources on the Authorization
+     * server, and is described in section 4.4 of the OAuth2 specification.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.4">https://tools.ietf.org/html/rfc6749#section-4.4</a>
+     */
+    ClientCredentials
 }

--- a/src/main/resources/liquibase/db.changelog-1.0.0.yaml
+++ b/src/main/resources/liquibase/db.changelog-1.0.0.yaml
@@ -204,7 +204,7 @@ databaseChangeLog:
                   nullable: false
             - column:
                 name: type
-                type: varchar(12)
+                type: varchar(18)
                 constraints:
                   nullable: false
             - column:

--- a/src/test/java/net/krotscheck/features/database/entity/ClientTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/ClientTest.java
@@ -93,9 +93,9 @@ public final class ClientTest {
     public void testGetSetType() {
         Client c = new Client();
 
-        Assert.assertEquals(ClientType.Public, c.getType());
-        c.setType(ClientType.Confidential);
-        Assert.assertEquals(ClientType.Confidential, c.getType());
+        Assert.assertEquals(ClientType.AuthorizationGrant, c.getType());
+        c.setType(ClientType.Implicit);
+        Assert.assertEquals(ClientType.Implicit, c.getType());
     }
 
     /**
@@ -167,7 +167,8 @@ public final class ClientTest {
     }
 
     /**
-     * Assert that this entity can be serialized into a JSON object, and doesn't
+     * Assert that this entity can be serialized into a JSON object, and
+     * doesn't
      * carry an unexpected payload.
      *
      * @throws Exception Should not be thrown.
@@ -199,7 +200,7 @@ public final class ClientTest {
         c.setModifiedDate(new Date());
         c.setName("name");
         c.setClientSecret("clientSecret");
-        c.setType(ClientType.Confidential);
+        c.setType(ClientType.AuthorizationGrant);
         c.setRedirects(redirects);
         c.setReferrers(referrers);
 
@@ -269,7 +270,7 @@ public final class ClientTest {
         node.put("createdDate", new Date().getTime());
         node.put("modifiedDate", new Date().getTime());
         node.put("name", "name");
-        node.put("type", "Confidential");
+        node.put("type", "Implicit");
         node.put("clientSecret", "clientSecret");
 
         ArrayNode referrers = node.arrayNode();

--- a/src/test/java/net/krotscheck/features/database/entity/ClientTypeTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/ClientTypeTest.java
@@ -37,11 +37,17 @@ public final class ClientTypeTest {
     public void testSerialization() throws Exception {
         ObjectMapper m = new ObjectMapper();
 
-        String authOutput = m.writeValueAsString(ClientType.Confidential);
-        Assert.assertEquals("\"Confidential\"", authOutput);
+        String auth = m.writeValueAsString(ClientType.AuthorizationGrant);
+        Assert.assertEquals("\"AuthorizationGrant\"", auth);
 
-        String bearerOutput = m.writeValueAsString(ClientType.Public);
-        Assert.assertEquals("\"Public\"", bearerOutput);
+        String implicit = m.writeValueAsString(ClientType.Implicit);
+        Assert.assertEquals("\"Implicit\"", implicit);
+
+        String owner = m.writeValueAsString(ClientType.OwnerCredentials);
+        Assert.assertEquals("\"OwnerCredentials\"", owner);
+
+        String client = m.writeValueAsString(ClientType.ClientCredentials);
+        Assert.assertEquals("\"ClientCredentials\"", client);
     }
 
     /**
@@ -52,11 +58,21 @@ public final class ClientTypeTest {
     @Test
     public void testDeserialization() throws Exception {
         ObjectMapper m = new ObjectMapper();
-        ClientType authOutput =
-                m.readValue("\"Confidential\"", ClientType.class);
-        Assert.assertSame(authOutput, ClientType.Confidential);
-        ClientType bearerOutput =
-                m.readValue("\"Public\"", ClientType.class);
-        Assert.assertSame(bearerOutput, ClientType.Public);
+
+        ClientType auth =
+                m.readValue("\"AuthorizationGrant\"", ClientType.class);
+        Assert.assertSame(auth, ClientType.AuthorizationGrant);
+
+        ClientType implicit =
+                m.readValue("\"Implicit\"", ClientType.class);
+        Assert.assertSame(implicit, ClientType.Implicit);
+
+        ClientType owner =
+                m.readValue("\"OwnerCredentials\"", ClientType.class);
+        Assert.assertSame(owner, ClientType.OwnerCredentials);
+
+        ClientType client =
+                m.readValue("\"ClientCredentials\"", ClientType.class);
+        Assert.assertSame(client, ClientType.ClientCredentials);
     }
 }


### PR DESCRIPTION
Let's try declaring client types by which flow they support, rather than
the far more generic "confidential" and "public".