### PR TITLE
Authenticators now link to clients, not applications.

### DIFF
--- a/src/main/java/net/krotscheck/features/database/entity/Application.java
+++ b/src/main/java/net/krotscheck/features/database/entity/Application.java
@@ -78,13 +78,6 @@ public final class Application extends AbstractEntity {
     private List<Role> roles;
 
     /**
-     * List of the application's authenticators.
-     */
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "application")
-    @JsonIgnore
-    private List<Authenticator> authenticators;
-
-    /**
      * The owner of the application.
      */
     @ManyToOne(fetch = FetchType.LAZY)
@@ -182,24 +175,6 @@ public final class Application extends AbstractEntity {
      */
     public void setRoles(final List<Role> roles) {
         this.roles = new ArrayList<>(roles);
-    }
-
-    /**
-     * The list of authenticators active in this application.
-     *
-     * @return The list of authenticators.
-     */
-    public List<Authenticator> getAuthenticators() {
-        return authenticators;
-    }
-
-    /**
-     * Set the authenticators.
-     *
-     * @param authenticators New list of authenticators.
-     */
-    public void setAuthenticators(final List<Authenticator> authenticators) {
-        this.authenticators = new ArrayList<>(authenticators);
     }
 
     /**

--- a/src/main/java/net/krotscheck/features/database/entity/Authenticator.java
+++ b/src/main/java/net/krotscheck/features/database/entity/Authenticator.java
@@ -50,13 +50,13 @@ import javax.persistence.Table;
 public final class Authenticator extends AbstractEntity {
 
     /**
-     * The Application to whom this authenticator belongs.
+     * The Client to whom this authenticator belongs.
      */
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "application", nullable = false, updatable = false)
+    @JoinColumn(name = "client", nullable = false, updatable = false)
     @JsonIdentityReference(alwaysAsId = true)
-    @JsonDeserialize(using = Application.Deserializer.class)
-    private Application application;
+    @JsonDeserialize(using = Client.Deserializer.class)
+    private Client client;
 
     /**
      * List of all identities assigned to this authenticator.
@@ -92,21 +92,21 @@ public final class Authenticator extends AbstractEntity {
     private Map<String, String> configuration;
 
     /**
-     * Get the application for this authenticator.
+     * Get the client for this authenticator.
      *
-     * @return The authenticator's application.
+     * @return The authenticator's client.
      */
-    public Application getApplication() {
-        return application;
+    public Client getClient() {
+        return client;
     }
 
     /**
-     * Set a new application for this authenticator.
+     * Set a new client for this authenticator.
      *
-     * @param application The new application.
+     * @param client The new client.
      */
-    public void setApplication(final Application application) {
-        this.application = application;
+    public void setClient(final Client client) {
+        this.client = client;
     }
 
     /**

--- a/src/main/java/net/krotscheck/features/database/entity/Client.java
+++ b/src/main/java/net/krotscheck/features/database/entity/Client.java
@@ -61,6 +61,13 @@ public final class Client extends AbstractEntity {
     private Application application;
 
     /**
+     * List of the application's authenticators.
+     */
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "client")
+    @JsonIgnore
+    private List<Authenticator> authenticators;
+
+    /**
      * OAuth tokens issued to this client.
      */
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "client")
@@ -204,6 +211,24 @@ public final class Client extends AbstractEntity {
      */
     public void setRedirects(final Set<URI> redirects) {
         this.redirects = redirects;
+    }
+
+    /**
+     * The list of authenticators active in this client.
+     *
+     * @return The list of authenticators.
+     */
+    public List<Authenticator> getAuthenticators() {
+        return authenticators;
+    }
+
+    /**
+     * Set the authenticators.
+     *
+     * @param authenticators New list of authenticators.
+     */
+    public void setAuthenticators(final List<Authenticator> authenticators) {
+        this.authenticators = new ArrayList<>(authenticators);
     }
 
     /**

--- a/src/main/resources/liquibase/db.changelog-1.0.0.yaml
+++ b/src/main/resources/liquibase/db.changelog-1.0.0.yaml
@@ -314,7 +314,7 @@ databaseChangeLog:
                 name: modifiedDate
                 type: datetime
             - column:
-                name: application
+                name: client
                 type: BINARY(16)
                 constraints:
                   nullable: false
@@ -324,13 +324,13 @@ databaseChangeLog:
                 constraints:
                   nullable: false
       - addForeignKeyConstraint:
-          baseColumnNames: application
+          baseColumnNames: client
           baseTableName: authenticators
-          constraintName: fk_authenticators_application
+          constraintName: fk_authenticators_client
           onDelete: CASCADE
           onUpdate: CASCADE
           referencedColumnNames: id
-          referencedTableName: applications
+          referencedTableName: clients
 
       # Each authenticator may require several custom configuration
       # parameters. Note that this table does not follow the

--- a/src/test/java/net/krotscheck/features/database/entity/ApplicationTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/ApplicationTest.java
@@ -115,21 +115,6 @@ public final class ApplicationTest {
     }
 
     /**
-     * Test get/set authenticator list.
-     */
-    @Test
-    public void testGetSetAuthenticators() {
-        Application a = new Application();
-        List<Authenticator> authenticators = new ArrayList<>();
-        authenticators.add(new Authenticator());
-
-        Assert.assertNull(a.getAuthenticators());
-        a.setAuthenticators(authenticators);
-        Assert.assertEquals(authenticators, a.getAuthenticators());
-        Assert.assertNotSame(authenticators, a.getAuthenticators());
-    }
-
-    /**
      * Test getting/setting the configuration.
      */
     @Test
@@ -171,11 +156,6 @@ public final class ApplicationTest {
         role.setId(UUID.randomUUID());
         roles.add(role);
 
-        List<Authenticator> authenticators = new ArrayList<>();
-        Authenticator authenticator = new Authenticator();
-        authenticator.setId(UUID.randomUUID());
-        authenticators.add(authenticator);
-
         Map<String, String> configuration = new HashMap<>();
         configuration.put("one", "value");
         configuration.put("two", "value");
@@ -192,7 +172,6 @@ public final class ApplicationTest {
         a.setClients(clients);
         a.setRoles(roles);
         a.setUsers(users);
-        a.setAuthenticators(authenticators);
 
         // De/serialize to json.
         ObjectMapper m = new ObjectMapper();
@@ -216,7 +195,6 @@ public final class ApplicationTest {
                 node.get("name").asText());
         Assert.assertFalse(node.has("clients"));
         Assert.assertFalse(node.has("roles"));
-        Assert.assertFalse(node.has("authenticators"));
         Assert.assertFalse(node.has("users"));
 
         // Get the configuration node.

--- a/src/test/java/net/krotscheck/features/database/entity/AuthenticatorTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/AuthenticatorTest.java
@@ -48,13 +48,13 @@ public final class AuthenticatorTest {
      * Test getting/setting the application.
      */
     @Test
-    public void testGetSetApplication() {
+    public void testGetSetClient() {
         Authenticator auth = new Authenticator();
-        Application a = new Application();
+        Client client = new Client();
 
-        Assert.assertNull(auth.getApplication());
-        auth.setApplication(a);
-        Assert.assertEquals(a, auth.getApplication());
+        Assert.assertNull(auth.getClient());
+        auth.setClient(client);
+        Assert.assertEquals(client, auth.getClient());
     }
 
     /**
@@ -113,15 +113,16 @@ public final class AuthenticatorTest {
     }
 
     /**
-     * Assert that this entity can be serialized into a JSON object, and doesn't
+     * Assert that this entity can be serialized into a JSON object, and
+     * doesn't
      * carry an unexpected payload.
      *
      * @throws Exception Should not be thrown.
      */
     @Test
     public void testJacksonSerializable() throws Exception {
-        Application application = new Application();
-        application.setId(UUID.randomUUID());
+        Client client = new Client();
+        client.setId(UUID.randomUUID());
 
         List<UserIdentity> identities = new ArrayList<>();
         UserIdentity identity = new UserIdentity();
@@ -139,7 +140,7 @@ public final class AuthenticatorTest {
 
         Authenticator a = new Authenticator();
         a.setId(UUID.randomUUID());
-        a.setApplication(application);
+        a.setClient(client);
         a.setCreatedDate(new Date());
         a.setModifiedDate(new Date());
         a.setType("type");
@@ -165,8 +166,8 @@ public final class AuthenticatorTest {
                 node.get("modifiedDate").asLong());
 
         Assert.assertEquals(
-                a.getApplication().getId().toString(),
-                node.get("application").asText());
+                a.getClient().getId().toString(),
+                node.get("client").asText());
         Assert.assertEquals(
                 a.getType(),
                 node.get("type").asText());

--- a/src/test/java/net/krotscheck/features/database/entity/ClientTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/ClientTest.java
@@ -167,6 +167,21 @@ public final class ClientTest {
     }
 
     /**
+     * Test get/set authenticator list.
+     */
+    @Test
+    public void testGetSetAuthenticators() {
+        Client client = new Client();
+        List<Authenticator> authenticators = new ArrayList<>();
+        authenticators.add(new Authenticator());
+
+        Assert.assertNull(client.getAuthenticators());
+        client.setAuthenticators(authenticators);
+        Assert.assertEquals(authenticators, client.getAuthenticators());
+        Assert.assertNotSame(authenticators, client.getAuthenticators());
+    }
+
+    /**
      * Assert that this entity can be serialized into a JSON object, and
      * doesn't
      * carry an unexpected payload.

--- a/src/test/resources/net/krotscheck/api/admin/v1/user/UserServiceTest.xml
+++ b/src/test/resources/net/krotscheck/api/admin/v1/user/UserServiceTest.xml
@@ -24,9 +24,14 @@
          application="uuid'00000000-0000-0000-0000-000000000001'"
          name="owner"/>
 
+  <clients id="uuid'00000000-0000-0000-0000-000000000001'"
+           application="uuid'00000000-0000-0000-0000-000000000001'"
+           type="Implicit"
+           name="Test Client"/>
+
   <authenticators
       id="uuid'00000000-0000-0000-0000-000000000001'"
-      application="uuid'00000000-0000-0000-0000-000000000001'"
+      client="uuid'00000000-0000-0000-0000-000000000001'"
       type="test_authenticator"
   />
 


### PR DESCRIPTION
Individual OAuth clients should be able to chose their own
authenticators.