### PR TITLE
Error response builder does not include httpStatus

### DIFF
--- a/src/main/java/net/krotscheck/features/exception/ErrorResponseBuilder.java
+++ b/src/main/java/net/krotscheck/features/exception/ErrorResponseBuilder.java
@@ -236,6 +236,7 @@ public final class ErrorResponseBuilder {
         /**
          * The error code.
          */
+        @JsonIgnore
         private int httpStatus = HttpStatus.SC_BAD_REQUEST;
 
         /**

--- a/src/test/java/net/krotscheck/features/exception/ExceptionFeatureTest.java
+++ b/src/test/java/net/krotscheck/features/exception/ExceptionFeatureTest.java
@@ -74,7 +74,6 @@ public final class ExceptionFeatureTest extends JerseyTest {
         ErrorResponse response = r.readEntity(ErrorResponse.class);
 
         Assert.assertEquals(404, r.getStatus());
-        Assert.assertEquals(404, response.getHttpStatus());
         Assert.assertEquals("not_found", response.getError());
         Assert.assertEquals("Not Found", response.getErrorDescription());
     }
@@ -89,7 +88,6 @@ public final class ExceptionFeatureTest extends JerseyTest {
         ErrorResponse response = r.readEntity(ErrorResponse.class);
 
         Assert.assertEquals(500, r.getStatus());
-        Assert.assertEquals(500, response.getHttpStatus());
         Assert.assertEquals("internal_server_error", response.getError());
         Assert.assertEquals("Internal Server Error",
                 response.getErrorDescription());
@@ -105,7 +103,6 @@ public final class ExceptionFeatureTest extends JerseyTest {
         ErrorResponse response = r.readEntity(ErrorResponse.class);
 
         Assert.assertEquals(400, r.getStatus());
-        Assert.assertEquals(400, response.getHttpStatus());
         Assert.assertEquals("bad_request", response.getError());
     }
 
@@ -119,7 +116,6 @@ public final class ExceptionFeatureTest extends JerseyTest {
         ErrorResponse response = r.readEntity(ErrorResponse.class);
 
         Assert.assertEquals(500, r.getStatus());
-        Assert.assertEquals(500, response.getHttpStatus());
         Assert.assertEquals("internal_server_error", response.getError());
         Assert.assertEquals("Internal Server Error",
                 response.getErrorDescription());


### PR DESCRIPTION
This patch adds a new test that asserts that the serialized object
returned from JsonMapping contain the expected values.