### PR TITLE
OAuth Token now uses DB ID as its identifier

### DIFF
--- a/src/main/java/net/krotscheck/features/database/entity/OAuthToken.java
+++ b/src/main/java/net/krotscheck/features/database/entity/OAuthToken.java
@@ -64,14 +64,6 @@ public final class OAuthToken extends AbstractEntity {
     private OAuthTokenType tokenType = OAuthTokenType.Bearer;
 
     /**
-     * The access token.
-     */
-    @Basic(optional = false)
-    @Column(name = "accessToken", unique = false, nullable = false,
-            updatable = false)
-    private String accessToken;
-
-    /**
      * Expires in how many seconds?
      */
     @Basic(optional = false)
@@ -130,24 +122,6 @@ public final class OAuthToken extends AbstractEntity {
      */
     public void setTokenType(final OAuthTokenType tokenType) {
         this.tokenType = tokenType;
-    }
-
-    /**
-     * Get the access token.
-     *
-     * @return The access token itself.
-     */
-    public String getAccessToken() {
-        return accessToken;
-    }
-
-    /**
-     * Set the access token.
-     *
-     * @param accessToken The access token itself.
-     */
-    public void setAccessToken(final String accessToken) {
-        this.accessToken = accessToken;
     }
 
     /**

--- a/src/main/resources/liquibase/db.changelog-1.0.0.yaml
+++ b/src/main/resources/liquibase/db.changelog-1.0.0.yaml
@@ -610,11 +610,6 @@ databaseChangeLog:
                 constraints:
                   nullable: false
             - column:
-                name: accessToken
-                type: varchar(255)
-                constraints:
-                  nullable: false
-            - column:
                 name: expiresIn
                 type: int
                 constraints:

--- a/src/test/java/net/krotscheck/features/database/entity/OAuthTokenTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/OAuthTokenTest.java
@@ -82,19 +82,6 @@ public final class OAuthTokenTest {
     }
 
     /**
-     * Assert that we can get and set access token.
-     */
-    @Test
-    public void testGetSetAccessToken() {
-        OAuthToken c = new OAuthToken();
-
-        // Default
-        Assert.assertNull(c.getAccessToken());
-        c.setAccessToken("token");
-        Assert.assertEquals("token", c.getAccessToken());
-    }
-
-    /**
      * Assert that we can get and set the expiration date.
      */
     @Test
@@ -128,7 +115,6 @@ public final class OAuthTokenTest {
         token.setIdentity(identity);
         token.setClient(client);
         token.setTokenType(OAuthTokenType.Authorization);
-        token.setAccessToken("accessToken");
         token.setExpiresIn(100);
 
         // De/serialize to json.
@@ -152,9 +138,6 @@ public final class OAuthTokenTest {
         Assert.assertEquals(
                 token.getExpiresIn(),
                 node.get("expiresIn").asLong());
-        Assert.assertEquals(
-                token.getAccessToken(),
-                node.get("accessToken").asText());
 
 
         Assert.assertFalse(node.has("client"));
@@ -166,7 +149,7 @@ public final class OAuthTokenTest {
         while (nameIterator.hasNext()) {
             names.add(nameIterator.next());
         }
-        Assert.assertEquals(6, names.size());
+        Assert.assertEquals(5, names.size());
     }
 
     /**
@@ -198,9 +181,6 @@ public final class OAuthTokenTest {
                 c.getModifiedDate().getTime(),
                 node.get("modifiedDate").asLong());
 
-        Assert.assertEquals(
-                c.getAccessToken(),
-                node.get("accessToken").asText());
         Assert.assertEquals(
                 c.getTokenType().toString(),
                 node.get("tokenType").asText());


### PR DESCRIPTION
We don't need to store an independent token ID, as we can now use
the DB UUID for this.