### PR TITLE
Created OAuthFilterChain annotation

### DIFF
--- a/src/main/java/net/krotscheck/api/oauth/annotation/OAuthFilterChain.java
+++ b/src/main/java/net/krotscheck/api/oauth/annotation/OAuthFilterChain.java
@@ -15,35 +15,26 @@
  * limitations under the License.
  */
 
-package net.krotscheck.api.oauth.resource;
+package net.krotscheck.api.oauth.annotation;
 
-import net.krotscheck.api.oauth.annotation.OAuthFilterChain;
-
-import javax.annotation.security.PermitAll;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.ws.rs.NameBinding;
 
 /**
- * The authorization service for our OAuth2 provider.
+ * This name binding annotation is used to annotate filters and service
+ * methods that make use of a particular filter chain.
+ *
+ * The OAuth filter chain is intended to include all pre-request filters that
+ * validate incoming requests.
  *
  * @author Michael Krotscheck
  */
-@Path("/authorize")
-@PermitAll
-@OAuthFilterChain
-public final class AuthorizationService {
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(value = RetentionPolicy.RUNTIME)
+@NameBinding
+public @interface OAuthFilterChain {
 
-    /**
-     * A stubbed resource.
-     *
-     * @return 200 OK
-     */
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response tokenRequest() {
-        return Response.ok().build();
-    }
 }

--- a/src/main/java/net/krotscheck/api/oauth/annotation/package-info.java
+++ b/src/main/java/net/krotscheck/api/oauth/annotation/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Custom annotations used by the OAuth Service.
+ */
+package net.krotscheck.api.oauth.annotation;

--- a/src/main/java/net/krotscheck/api/oauth/resource/TokenService.java
+++ b/src/main/java/net/krotscheck/api/oauth/resource/TokenService.java
@@ -17,6 +17,8 @@
 
 package net.krotscheck.api.oauth.resource;
 
+import net.krotscheck.api.oauth.annotation.OAuthFilterChain;
+
 import javax.annotation.security.PermitAll;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -31,6 +33,7 @@ import javax.ws.rs.core.Response;
  */
 @Path("/token")
 @PermitAll
+@OAuthFilterChain
 public final class TokenService {
 
     /**


### PR DESCRIPTION
This annotation can be used to map post-path-matched filters to
apply to specific paths. In this case, it is intended to mark
filters required for OAuth requests.