### PR TITLE
OAuthToken Identity is optional.

### DIFF
--- a/src/main/java/net/krotscheck/features/database/entity/OAuthToken.java
+++ b/src/main/java/net/krotscheck/features/database/entity/OAuthToken.java
@@ -49,7 +49,7 @@ public final class OAuthToken extends AbstractEntity {
      * The authenticated user identity.
      */
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "identity", nullable = false, updatable = false)
+    @JoinColumn(name = "identity", nullable = true, updatable = false)
     @JsonIgnore
     private UserIdentity identity;
 

--- a/src/main/resources/liquibase/db.changelog-1.0.0.yaml
+++ b/src/main/resources/liquibase/db.changelog-1.0.0.yaml
@@ -701,7 +701,7 @@ databaseChangeLog:
                 name: identity
                 type: BINARY(16)
                 constraints:
-                  nullable: false
+                  nullable: true
             - column:
                 name: client
                 type: BINARY(16)


### PR DESCRIPTION
Several flows exist that are not expressly attached to a user
(such as the Client Credentials flow). As such, we cannot make
the user-identity column required.