### PR TITLE
Added some default configuration parsing to Client

### DIFF
--- a/src/main/java/net/krotscheck/features/database/entity/Client.java
+++ b/src/main/java/net/krotscheck/features/database/entity/Client.java
@@ -318,6 +318,42 @@ public final class Client extends AbstractEntity {
     }
 
     /**
+     * Extract the access token expiration time (in seconds) for this client.
+     * This value is derived from the default configuration values, or from a
+     * default, if such exists.
+     *
+     * @return The expiration horizon of an access token, in seconds.
+     */
+    @JsonIgnore
+    public Integer getAccessTokenExpireIn() {
+        try {
+            Map<String, String> config = getConfiguration();
+            String value = config.get(ClientConfig.ACCESS_TOKEN_EXPIRES_NAME);
+            return Integer.parseInt(value);
+        } catch (Exception e) {
+            return ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT;
+        }
+    }
+
+    /**
+     * Extract the refresh token expiration time (in seconds) for this client.
+     * This value is derived from the default configuration values, or from a
+     * default, if such exists.
+     *
+     * @return The expiration horizon of an access token, in seconds.
+     */
+    @JsonIgnore
+    public Integer getRefreshTokenExpireIn() {
+        try {
+            Map<String, String> config = getConfiguration();
+            String value = config.get(ClientConfig.REFRESH_TOKEN_EXPIRES_NAME);
+            return Integer.parseInt(value);
+        } catch (Exception e) {
+            return ClientConfig.REFRESH_TOKEN_EXPIRES_DEFAULT;
+        }
+    }
+
+    /**
      * Deserialize a reference to an User.
      *
      * @author Michael Krotschecks

--- a/src/main/java/net/krotscheck/features/database/entity/ClientConfig.java
+++ b/src/main/java/net/krotscheck/features/database/entity/ClientConfig.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.features.database.entity;
+
+/**
+ * This represents a registered client, as well as it's connection metadata,
+ * for
+ * a specific application. Multiple different clients may exist per
+ * application.
+ *
+ * @author Michael Krotscheck
+ */
+public final class ClientConfig {
+
+    /**
+     * Utility method, client configuration.
+     */
+    private ClientConfig() {
+
+    }
+
+    /**
+     * The configuration name for OAuth Token Expiration.
+     */
+    public static final String ACCESS_TOKEN_EXPIRES_NAME
+            = "access_token_expires_in";
+
+    /**
+     * The default value for OAuth Token Expiration (10 minutes).
+     */
+    public static final Integer ACCESS_TOKEN_EXPIRES_DEFAULT =
+            60 * 10;
+
+    /**
+     * The configuration name for OAuth Token Expiration.
+     */
+    public static final String REFRESH_TOKEN_EXPIRES_NAME
+            = "refresh_token_expires_in";
+
+    /**
+     * The default value for OAuth Token Expiration (1 month).
+     */
+    public static final Integer REFRESH_TOKEN_EXPIRES_DEFAULT =
+            60 * 60 * 24 * 30;
+}

--- a/src/test/java/net/krotscheck/features/database/entity/ClientConfigTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/ClientConfigTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.features.database.entity;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+/**
+ * Unit tests for our configuration defaults.
+ *
+ * @author Michael Krotscheck
+ */
+public final class ClientConfigTest {
+
+    /**
+     * Assert that the header is private.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testPrivateConstructor() throws Exception {
+        Constructor c = ClientConfig.class.getDeclaredConstructor();
+        Assert.assertTrue(Modifier.isPrivate(c.getModifiers()));
+
+        // Create a new instance for coverage.
+        c.setAccessible(true);
+        c.newInstance();
+    }
+
+    /**
+     * Test the config values for the access token.
+     */
+    @Test
+    public void testAccessTokenDefaults() {
+        Integer expectedDefault = 60 * 10; // 10 minutes.
+        Assert.assertEquals(expectedDefault,
+                ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT);
+        Assert.assertEquals("access_token_expires_in",
+                ClientConfig.ACCESS_TOKEN_EXPIRES_NAME);
+    }
+
+    /**
+     * Test the config values for the refresh token.
+     */
+    @Test
+    public void testRefreshTokenDefaults() {
+        Integer expectedDefault = 60 * 60 * 24 * 30; // One month.
+        Assert.assertEquals(expectedDefault,
+                ClientConfig.REFRESH_TOKEN_EXPIRES_DEFAULT);
+        Assert.assertEquals("refresh_token_expires_in",
+                ClientConfig.REFRESH_TOKEN_EXPIRES_NAME);
+    }
+}

--- a/src/test/java/net/krotscheck/features/database/entity/ClientTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/ClientTest.java
@@ -198,6 +198,62 @@ public final class ClientTest {
     }
 
     /**
+     * Assert that we can get the default values for the access expires in
+     * token.
+     */
+    @Test
+    public void testGetAccessExpiresIn() {
+        Client client = new Client();
+        Map<String, String> configuration = new HashMap<>();
+        Integer expectedDefault = 10 * 60; // Ten minutes
+
+        // Assert no config.
+        Assert.assertEquals(expectedDefault, client.getAccessTokenExpireIn());
+
+        // Assert empty config.
+        client.setConfiguration(configuration);
+        Assert.assertEquals(expectedDefault, client.getAccessTokenExpireIn());
+
+        // Assert unparseable config
+        configuration.put(ClientConfig.ACCESS_TOKEN_EXPIRES_NAME, "not_an_int");
+        client.setConfiguration(configuration);
+        Assert.assertEquals(expectedDefault, client.getAccessTokenExpireIn());
+
+        // Assert parseable config
+        configuration.put(ClientConfig.ACCESS_TOKEN_EXPIRES_NAME, "50");
+        client.setConfiguration(configuration);
+        Assert.assertEquals((Integer) 50, client.getAccessTokenExpireIn());
+    }
+
+    /**
+     * Assert that we can get the default values for the refresh token.
+     */
+    @Test
+    public void testGetRefreshExpiresIn() {
+        Client client = new Client();
+        Map<String, String> configuration = new HashMap<>();
+        Integer expectedDefault = 60 * 60 * 24 * 30; // One month.
+
+        // Assert no config.
+        Assert.assertEquals(expectedDefault, client.getRefreshTokenExpireIn());
+
+        // Assert empty config.
+        client.setConfiguration(configuration);
+        Assert.assertEquals(expectedDefault, client.getRefreshTokenExpireIn());
+
+        // Assert unparseable config
+        configuration
+                .put(ClientConfig.REFRESH_TOKEN_EXPIRES_NAME, "not_an_int");
+        client.setConfiguration(configuration);
+        Assert.assertEquals(expectedDefault, client.getRefreshTokenExpireIn());
+
+        // Assert parseable config
+        configuration.put(ClientConfig.REFRESH_TOKEN_EXPIRES_NAME, "50");
+        client.setConfiguration(configuration);
+        Assert.assertEquals((Integer) 50, client.getRefreshTokenExpireIn());
+    }
+
+    /**
      * Assert that this entity can be serialized into a JSON object, and
      * doesn't
      * carry an unexpected payload.


### PR DESCRIPTION
Some very basic configuration default fallbacks for the client
configuration. This should probably be expanded.