### PR TITLE
Switched to using Java8 Calendar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -641,6 +641,11 @@
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-java8</artifactId>
+      <version>${hibernate.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
       <version>${hibernate.version}</version>
     </dependency>

--- a/src/main/java/net/krotscheck/features/database/entity/AbstractEntity.java
+++ b/src/main/java/net/krotscheck/features/database/entity/AbstractEntity.java
@@ -37,7 +37,7 @@ import org.hibernate.search.annotations.Parameter;
 import org.hibernate.search.annotations.TokenFilterDef;
 import org.hibernate.search.annotations.TokenizerDef;
 
-import java.util.Date;
+import java.util.Calendar;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.GeneratedValue;
@@ -86,13 +86,13 @@ public abstract class AbstractEntity {
      * The date this record was created.
      */
     @Column(name = "createdDate")
-    private Date createdDate;
+    private Calendar createdDate;
 
     /**
      * The date this record was last modified.
      */
     @Column(name = "modifiedDate")
-    private Date modifiedDate;
+    private Calendar modifiedDate;
 
     /**
      * Return the DB record's ID.
@@ -117,11 +117,11 @@ public abstract class AbstractEntity {
      *
      * @return The created date.
      */
-    public final Date getCreatedDate() {
+    public final Calendar getCreatedDate() {
         if (createdDate == null) {
             return null;
         } else {
-            return new Date(createdDate.getTime());
+            return (Calendar) createdDate.clone();
         }
     }
 
@@ -130,8 +130,8 @@ public abstract class AbstractEntity {
      *
      * @param date The creation date for this entity.
      */
-    public final void setCreatedDate(final Date date) {
-        this.createdDate = new Date(date.getTime());
+    public final void setCreatedDate(final Calendar date) {
+        this.createdDate = (Calendar) date.clone();
     }
 
     /**
@@ -139,11 +139,11 @@ public abstract class AbstractEntity {
      *
      * @return The last time this record was modified, or null.
      */
-    public final Date getModifiedDate() {
+    public final Calendar getModifiedDate() {
         if (modifiedDate == null) {
             return null;
         } else {
-            return new Date(modifiedDate.getTime());
+            return (Calendar) modifiedDate.clone();
         }
     }
 
@@ -152,8 +152,8 @@ public abstract class AbstractEntity {
      *
      * @param date The modified date for this entity.
      */
-    public final void setModifiedDate(final Date date) {
-        this.modifiedDate = new Date(date.getTime());
+    public final void setModifiedDate(final Calendar date) {
+        this.modifiedDate = (Calendar) date.clone();
     }
 
     /**

--- a/src/main/java/net/krotscheck/features/database/listener/CreatedUpdatedListener.java
+++ b/src/main/java/net/krotscheck/features/database/listener/CreatedUpdatedListener.java
@@ -24,7 +24,8 @@ import org.hibernate.event.spi.PreInsertEventListener;
 import org.hibernate.event.spi.PreUpdateEvent;
 import org.hibernate.event.spi.PreUpdateEventListener;
 
-import java.util.Date;
+import java.util.Calendar;
+import java.util.TimeZone;
 import javax.inject.Singleton;
 
 /**
@@ -35,6 +36,11 @@ import javax.inject.Singleton;
  */
 public final class CreatedUpdatedListener
         implements PreInsertEventListener, PreUpdateEventListener {
+
+    /**
+     * The timezone. Everything we're doing is UTC.
+     */
+    private final TimeZone timeZone = TimeZone.getTimeZone("UTC");
 
     /**
      * Before insert, update the createdDate and modifiedDate.
@@ -48,8 +54,8 @@ public final class CreatedUpdatedListener
         if (entity instanceof AbstractEntity) {
 
             AbstractEntity persistingEntity = (AbstractEntity) entity;
-            persistingEntity.setCreatedDate(new Date());
-            persistingEntity.setModifiedDate(new Date());
+            persistingEntity.setCreatedDate(Calendar.getInstance(timeZone));
+            persistingEntity.setModifiedDate(Calendar.getInstance(timeZone));
         }
 
         return false;
@@ -67,7 +73,7 @@ public final class CreatedUpdatedListener
         if (entity instanceof AbstractEntity) {
 
             AbstractEntity persistingEntity = (AbstractEntity) entity;
-            persistingEntity.setModifiedDate(new Date());
+            persistingEntity.setModifiedDate(Calendar.getInstance(timeZone));
         }
 
         return false;

--- a/src/main/java/net/krotscheck/features/jackson/ObjectMapperFactory.java
+++ b/src/main/java/net/krotscheck/features/jackson/ObjectMapperFactory.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import org.glassfish.hk2.api.Factory;
 import org.glassfish.hk2.api.ServiceLocator;
@@ -89,6 +90,9 @@ public final class ObjectMapperFactory implements Factory<ObjectMapper> {
                 SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
         mapper.configure(
                 SerializationFeature.WRITE_NULL_MAP_VALUES, false);
+
+        // Make sure date format is ISO Compliant.
+        mapper.setDateFormat(new ISO8601DateFormat());
 
         // Add our annotation introspectors.
         AnnotationIntrospector jaxbIntrospector =

--- a/src/test/java/net/krotscheck/features/database/entity/AbstractEntityTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/AbstractEntityTest.java
@@ -20,7 +20,7 @@ package net.krotscheck.features.database.entity;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Date;
+import java.util.Calendar;
 import java.util.UUID;
 
 /**
@@ -46,7 +46,7 @@ public final class AbstractEntityTest {
     @Test
     public void testGetSetCreatedDate() {
         AbstractEntity a = new TestEntity();
-        Date d = new Date();
+        Calendar d = Calendar.getInstance();
 
         Assert.assertNull(a.getCreatedDate());
         a.setCreatedDate(d);
@@ -60,7 +60,7 @@ public final class AbstractEntityTest {
     @Test
     public void testGetSetModifiedDate() {
         AbstractEntity a = new TestEntity();
-        Date d = new Date();
+        Calendar d = Calendar.getInstance();
 
         Assert.assertNull(a.getModifiedDate());
         a.setModifiedDate(d);

--- a/src/test/java/net/krotscheck/features/database/entity/ApplicationScopeTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/ApplicationScopeTest.java
@@ -23,11 +23,15 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import net.krotscheck.features.database.entity.ApplicationScope.Deserializer;
+import net.krotscheck.test.JacksonUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.text.DateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -112,25 +116,27 @@ public final class ApplicationScopeTest {
 
         ApplicationScope a = new ApplicationScope();
         a.setId(UUID.randomUUID());
-        a.setCreatedDate(new Date());
-        a.setModifiedDate(new Date());
+        a.setCreatedDate(Calendar.getInstance());
+        a.setModifiedDate(Calendar.getInstance());
         a.setApplication(application);
         a.setName("name");
 
         // De/serialize to json.
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
         String output = m.writeValueAsString(a);
         JsonNode node = m.readTree(output);
+
+        DateFormat format = new ISO8601DateFormat();
 
         Assert.assertEquals(
                 a.getId().toString(),
                 node.get("id").asText());
         Assert.assertEquals(
-                a.getCreatedDate().getTime(),
-                node.get("createdDate").asLong());
+                format.format(a.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
         Assert.assertEquals(
-                a.getModifiedDate().getTime(),
-                node.get("modifiedDate").asLong());
+                format.format(a.getCreatedDate().getTime()),
+                node.get("modifiedDate").asText());
         Assert.assertEquals(
                 a.getApplication().getId().toString(),
                 node.get("application").asText());
@@ -154,11 +160,14 @@ public final class ApplicationScopeTest {
      */
     @Test
     public void testJacksonDeserializable() throws Exception {
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
         ObjectNode node = m.createObjectNode();
         node.put("id", UUID.randomUUID().toString());
-        node.put("createdDate", new Date().getTime());
-        node.put("modifiedDate", new Date().getTime());
+        node.put("createdDate",
+                format.format(Calendar.getInstance().getTime()));
+        node.put("modifiedDate",
+                format.format(Calendar.getInstance().getTime()));
         node.put("name", "name");
 
         String output = m.writeValueAsString(node);
@@ -168,11 +177,11 @@ public final class ApplicationScopeTest {
                 a.getId().toString(),
                 node.get("id").asText());
         Assert.assertEquals(
-                a.getCreatedDate().getTime(),
-                node.get("createdDate").asLong());
+                format.format(a.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
         Assert.assertEquals(
-                a.getModifiedDate().getTime(),
-                node.get("modifiedDate").asLong());
+                format.format(a.getModifiedDate().getTime()),
+                node.get("modifiedDate").asText());
         Assert.assertEquals(
                 a.getName(),
                 node.get("name").asText());

--- a/src/test/java/net/krotscheck/features/database/entity/ApplicationTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/ApplicationTest.java
@@ -23,11 +23,17 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import net.krotscheck.features.database.entity.Application.Deserializer;
+import net.krotscheck.features.jackson.ObjectMapperFactory;
+import net.krotscheck.test.JacksonUtil;
+import org.glassfish.hk2.api.ServiceLocator;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.text.DateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -159,8 +165,8 @@ public final class ApplicationTest {
 
         Application a = new Application();
         a.setId(UUID.randomUUID());
-        a.setCreatedDate(new Date());
-        a.setModifiedDate(new Date());
+        a.setCreatedDate(Calendar.getInstance());
+        a.setModifiedDate(Calendar.getInstance());
         a.setOwner(owner);
         a.setName("name");
 
@@ -170,7 +176,8 @@ public final class ApplicationTest {
         a.setUsers(users);
 
         // De/serialize to json.
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
         String output = m.writeValueAsString(a);
         JsonNode node = m.readTree(output);
 
@@ -178,11 +185,11 @@ public final class ApplicationTest {
                 a.getId().toString(),
                 node.get("id").asText());
         Assert.assertEquals(
-                a.getCreatedDate().getTime(),
-                node.get("createdDate").asLong());
+                format.format(a.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
         Assert.assertEquals(
-                a.getModifiedDate().getTime(),
-                node.get("modifiedDate").asLong());
+                format.format(a.getCreatedDate().getTime()),
+                node.get("modifiedDate").asText());
         Assert.assertEquals(
                 a.getOwner().getId().toString(),
                 node.get("owner").asText());
@@ -209,11 +216,14 @@ public final class ApplicationTest {
      */
     @Test
     public void testJacksonDeserializable() throws Exception {
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
         ObjectNode node = m.createObjectNode();
         node.put("id", UUID.randomUUID().toString());
-        node.put("createdDate", new Date().getTime());
-        node.put("modifiedDate", new Date().getTime());
+        node.put("createdDate",
+                format.format(Calendar.getInstance().getTime()));
+        node.put("modifiedDate",
+                format.format(Calendar.getInstance().getTime()));
         node.put("name", "name");
 
         String output = m.writeValueAsString(node);
@@ -223,11 +233,11 @@ public final class ApplicationTest {
                 a.getId().toString(),
                 node.get("id").asText());
         Assert.assertEquals(
-                a.getCreatedDate().getTime(),
-                node.get("createdDate").asLong());
+                format.format(a.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
         Assert.assertEquals(
-                a.getModifiedDate().getTime(),
-                node.get("modifiedDate").asLong());
+                format.format(a.getModifiedDate().getTime()),
+                node.get("modifiedDate").asText());
         Assert.assertEquals(
                 a.getName(),
                 node.get("name").asText());

--- a/src/test/java/net/krotscheck/features/database/entity/AuthenticatorStateTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/AuthenticatorStateTest.java
@@ -23,11 +23,15 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import net.krotscheck.features.database.entity.AuthenticatorState.Deserializer;
+import net.krotscheck.test.JacksonUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.text.DateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -149,8 +153,8 @@ public final class AuthenticatorStateTest {
 
         AuthenticatorState state = new AuthenticatorState();
         state.setId(UUID.randomUUID());
-        state.setCreatedDate(new Date());
-        state.setModifiedDate(new Date());
+        state.setCreatedDate(Calendar.getInstance());
+        state.setModifiedDate(Calendar.getInstance());
         state.setAuthenticator(authenticator);
         state.setClient(client);
         state.setAuthenticatorState("authenticatorState");
@@ -160,7 +164,8 @@ public final class AuthenticatorStateTest {
         state.setClientScope("clientScope");
 
         // De/serialize to json.
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
         String output = m.writeValueAsString(state);
         JsonNode node = m.readTree(output);
 
@@ -168,11 +173,11 @@ public final class AuthenticatorStateTest {
                 state.getId().toString(),
                 node.get("id").asText());
         Assert.assertEquals(
-                state.getCreatedDate().getTime(),
-                node.get("createdDate").asLong());
+                format.format(state.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
         Assert.assertEquals(
-                state.getModifiedDate().getTime(),
-                node.get("modifiedDate").asLong());
+                format.format(state.getCreatedDate().getTime()),
+                node.get("modifiedDate").asText());
 
         Assert.assertEquals(
                 state.getAuthenticator().getId().toString(),
@@ -212,11 +217,14 @@ public final class AuthenticatorStateTest {
      */
     @Test
     public void testJacksonDeserializable() throws Exception {
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
         ObjectNode node = m.createObjectNode();
         node.put("id", UUID.randomUUID().toString());
-        node.put("createdDate", new Date().getTime());
-        node.put("modifiedDate", new Date().getTime());
+        node.put("createdDate",
+                format.format(Calendar.getInstance().getTime()));
+        node.put("modifiedDate",
+                format.format(Calendar.getInstance().getTime()));
         node.put("authenticatorState", "authenticatorState");
         node.put("authenticatorNonce", "authenticatorNonce");
         node.put("clientState", "clientState");
@@ -230,11 +238,11 @@ public final class AuthenticatorStateTest {
                 c.getId().toString(),
                 node.get("id").asText());
         Assert.assertEquals(
-                c.getCreatedDate().getTime(),
-                node.get("createdDate").asLong());
+                format.format(c.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
         Assert.assertEquals(
-                c.getModifiedDate().getTime(),
-                node.get("modifiedDate").asLong());
+                format.format(c.getModifiedDate().getTime()),
+                node.get("modifiedDate").asText());
 
         Assert.assertEquals(
                 c.getAuthenticatorState(),

--- a/src/test/java/net/krotscheck/features/database/entity/AuthenticatorTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/AuthenticatorTest.java
@@ -23,11 +23,15 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import net.krotscheck.features.database.entity.Authenticator.Deserializer;
+import net.krotscheck.test.JacksonUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.text.DateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -141,8 +145,8 @@ public final class AuthenticatorTest {
         Authenticator a = new Authenticator();
         a.setId(UUID.randomUUID());
         a.setClient(client);
-        a.setCreatedDate(new Date());
-        a.setModifiedDate(new Date());
+        a.setCreatedDate(Calendar.getInstance());
+        a.setModifiedDate(Calendar.getInstance());
         a.setType("type");
         a.setConfiguration(config);
 
@@ -151,7 +155,8 @@ public final class AuthenticatorTest {
         a.setStates(states);
 
         // De/serialize to json.
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
         String output = m.writeValueAsString(a);
         JsonNode node = m.readTree(output);
 
@@ -159,11 +164,11 @@ public final class AuthenticatorTest {
                 a.getId().toString(),
                 node.get("id").asText());
         Assert.assertEquals(
-                a.getCreatedDate().getTime(),
-                node.get("createdDate").asLong());
+                format.format(a.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
         Assert.assertEquals(
-                a.getModifiedDate().getTime(),
-                node.get("modifiedDate").asLong());
+                format.format(a.getCreatedDate().getTime()),
+                node.get("modifiedDate").asText());
 
         Assert.assertEquals(
                 a.getClient().getId().toString(),
@@ -200,11 +205,14 @@ public final class AuthenticatorTest {
      */
     @Test
     public void testJacksonDeserializable() throws Exception {
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
         ObjectNode node = m.createObjectNode();
         node.put("id", UUID.randomUUID().toString());
-        node.put("createdDate", new Date().getTime());
-        node.put("modifiedDate", new Date().getTime());
+        node.put("createdDate",
+                format.format(Calendar.getInstance().getTime()));
+        node.put("modifiedDate",
+                format.format(Calendar.getInstance().getTime()));
         node.put("type", "type");
 
         ObjectNode configNode = m.createObjectNode();
@@ -219,11 +227,11 @@ public final class AuthenticatorTest {
                 a.getId().toString(),
                 node.get("id").asText());
         Assert.assertEquals(
-                a.getCreatedDate().getTime(),
-                node.get("createdDate").asLong());
+                format.format(a.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
         Assert.assertEquals(
-                a.getModifiedDate().getTime(),
-                node.get("modifiedDate").asLong());
+                format.format(a.getModifiedDate().getTime()),
+                node.get("modifiedDate").asText());
 
         Assert.assertEquals(
                 a.getType(),

--- a/src/test/java/net/krotscheck/features/database/entity/ClientTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/ClientTest.java
@@ -24,12 +24,16 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import net.krotscheck.features.database.entity.Client.Deserializer;
+import net.krotscheck.test.JacksonUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.URI;
+import java.text.DateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -320,8 +324,8 @@ public final class ClientTest {
         Client c = new Client();
         c.setApplication(application);
         c.setId(UUID.randomUUID());
-        c.setCreatedDate(new Date());
-        c.setModifiedDate(new Date());
+        c.setCreatedDate(Calendar.getInstance());
+        c.setModifiedDate(Calendar.getInstance());
         c.setName("name");
         c.setClientSecret("clientSecret");
         c.setType(ClientType.AuthorizationGrant);
@@ -334,7 +338,8 @@ public final class ClientTest {
         c.setStates(states);
 
         // De/serialize to json.
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
         String output = m.writeValueAsString(c);
         JsonNode node = m.readTree(output);
 
@@ -342,11 +347,11 @@ public final class ClientTest {
                 c.getId().toString(),
                 node.get("id").asText());
         Assert.assertEquals(
-                c.getCreatedDate().getTime(),
-                node.get("createdDate").asLong());
+                format.format(c.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
         Assert.assertEquals(
-                c.getModifiedDate().getTime(),
-                node.get("modifiedDate").asLong());
+                format.format(c.getCreatedDate().getTime()),
+                node.get("modifiedDate").asText());
 
         Assert.assertEquals(
                 c.getApplication().getId().toString(),
@@ -398,11 +403,14 @@ public final class ClientTest {
      */
     @Test
     public void testJacksonDeserializable() throws Exception {
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
         ObjectNode node = m.createObjectNode();
         node.put("id", UUID.randomUUID().toString());
-        node.put("createdDate", new Date().getTime());
-        node.put("modifiedDate", new Date().getTime());
+        node.put("createdDate",
+                format.format(Calendar.getInstance().getTime()));
+        node.put("modifiedDate",
+                format.format(Calendar.getInstance().getTime()));
         node.put("name", "name");
         node.put("type", "Implicit");
         node.put("clientSecret", "clientSecret");
@@ -427,11 +435,11 @@ public final class ClientTest {
                 c.getId().toString(),
                 node.get("id").asText());
         Assert.assertEquals(
-                c.getCreatedDate().getTime(),
-                node.get("createdDate").asLong());
+                format.format(c.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
         Assert.assertEquals(
-                c.getModifiedDate().getTime(),
-                node.get("modifiedDate").asLong());
+                format.format(c.getModifiedDate().getTime()),
+                node.get("modifiedDate").asText());
 
         Assert.assertEquals(
                 c.getName(),

--- a/src/test/java/net/krotscheck/features/database/entity/ClientTypeTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/ClientTypeTest.java
@@ -18,8 +18,13 @@
 package net.krotscheck.features.database.entity;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import net.krotscheck.features.jackson.ObjectMapperFactory;
+import net.krotscheck.test.JacksonUtil;
+import org.glassfish.hk2.api.ServiceLocator;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * Unit tests for the client type.
@@ -35,7 +40,7 @@ public final class ClientTypeTest {
      */
     @Test
     public void testSerialization() throws Exception {
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
 
         String auth = m.writeValueAsString(ClientType.AuthorizationGrant);
         Assert.assertEquals("\"AuthorizationGrant\"", auth);
@@ -57,7 +62,7 @@ public final class ClientTypeTest {
      */
     @Test
     public void testDeserialization() throws Exception {
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
 
         ClientType auth =
                 m.readValue("\"AuthorizationGrant\"", ClientType.class);

--- a/src/test/java/net/krotscheck/features/database/entity/OAuthTokenTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/OAuthTokenTest.java
@@ -23,11 +23,17 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import net.krotscheck.features.database.entity.OAuthToken.Deserializer;
+import net.krotscheck.features.jackson.ObjectMapperFactory;
+import net.krotscheck.test.JacksonUtil;
+import org.glassfish.hk2.api.ServiceLocator;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.text.DateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -126,15 +132,16 @@ public final class OAuthTokenTest {
 
         OAuthToken token = new OAuthToken();
         token.setId(UUID.randomUUID());
-        token.setCreatedDate(new Date());
-        token.setModifiedDate(new Date());
+        token.setCreatedDate(Calendar.getInstance());
+        token.setModifiedDate(Calendar.getInstance());
         token.setIdentity(identity);
         token.setClient(client);
         token.setTokenType(OAuthTokenType.Authorization);
         token.setExpiresIn(100);
 
         // De/serialize to json.
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
         String output = m.writeValueAsString(token);
         JsonNode node = m.readTree(output);
 
@@ -142,11 +149,11 @@ public final class OAuthTokenTest {
                 token.getId().toString(),
                 node.get("id").asText());
         Assert.assertEquals(
-                token.getCreatedDate().getTime(),
-                node.get("createdDate").asLong());
+                format.format(token.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
         Assert.assertEquals(
-                token.getModifiedDate().getTime(),
-                node.get("modifiedDate").asLong());
+                format.format(token.getCreatedDate().getTime()),
+                node.get("modifiedDate").asText());
 
         Assert.assertEquals(
                 token.getTokenType().toString(),
@@ -175,11 +182,14 @@ public final class OAuthTokenTest {
      */
     @Test
     public void testJacksonDeserializable() throws Exception {
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
         ObjectNode node = m.createObjectNode();
         node.put("id", UUID.randomUUID().toString());
-        node.put("createdDate", new Date().getTime());
-        node.put("modifiedDate", new Date().getTime());
+        node.put("createdDate",
+                format.format(Calendar.getInstance().getTime()));
+        node.put("modifiedDate",
+                format.format(Calendar.getInstance().getTime()));
         node.put("accessToken", "accessToken");
         node.put("tokenType", "Authorization");
         node.put("expiresIn", 300);
@@ -191,11 +201,11 @@ public final class OAuthTokenTest {
                 c.getId().toString(),
                 node.get("id").asText());
         Assert.assertEquals(
-                c.getCreatedDate().getTime(),
-                node.get("createdDate").asLong());
+                format.format(c.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
         Assert.assertEquals(
-                c.getModifiedDate().getTime(),
-                node.get("modifiedDate").asLong());
+                format.format(c.getModifiedDate().getTime()),
+                node.get("modifiedDate").asText());
 
         Assert.assertEquals(
                 c.getTokenType().toString(),

--- a/src/test/java/net/krotscheck/features/database/entity/OAuthTokenTypeTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/OAuthTokenTypeTest.java
@@ -18,8 +18,13 @@
 package net.krotscheck.features.database.entity;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import net.krotscheck.features.jackson.ObjectMapperFactory;
+import net.krotscheck.test.JacksonUtil;
+import org.glassfish.hk2.api.ServiceLocator;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * Unit tests for the token type.
@@ -35,7 +40,7 @@ public final class OAuthTokenTypeTest {
      */
     @Test
     public void testSerialization() throws Exception {
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
 
         String authOutput = m.writeValueAsString(OAuthTokenType.Authorization);
         Assert.assertEquals("\"Authorization\"", authOutput);
@@ -54,7 +59,7 @@ public final class OAuthTokenTypeTest {
      */
     @Test
     public void testDeserialization() throws Exception {
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
         OAuthTokenType authOutput =
                 m.readValue("\"Authorization\"", OAuthTokenType.class);
         Assert.assertSame(authOutput, OAuthTokenType.Authorization);

--- a/src/test/java/net/krotscheck/features/database/entity/RoleTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/RoleTest.java
@@ -23,11 +23,17 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import net.krotscheck.features.database.entity.Role.Deserializer;
+import net.krotscheck.features.jackson.ObjectMapperFactory;
+import net.krotscheck.test.JacksonUtil;
+import org.glassfish.hk2.api.ServiceLocator;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.text.DateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -118,13 +124,14 @@ public final class RoleTest {
         Role role = new Role();
         role.setApplication(a);
         role.setId(UUID.randomUUID());
-        role.setCreatedDate(new Date());
-        role.setModifiedDate(new Date());
+        role.setCreatedDate(Calendar.getInstance());
+        role.setModifiedDate(Calendar.getInstance());
         role.setName("name");
         role.setUsers(users);
 
         // De/serialize to json.
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
         String output = m.writeValueAsString(role);
         JsonNode node = m.readTree(output);
 
@@ -132,11 +139,11 @@ public final class RoleTest {
                 role.getId().toString(),
                 node.get("id").asText());
         Assert.assertEquals(
-                role.getCreatedDate().getTime(),
-                node.get("createdDate").asLong());
+                format.format(role.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
         Assert.assertEquals(
-                role.getModifiedDate().getTime(),
-                node.get("modifiedDate").asLong());
+                format.format(role.getCreatedDate().getTime()),
+                node.get("modifiedDate").asText());
 
         Assert.assertEquals(
                 role.getApplication().getId().toString(),
@@ -164,11 +171,14 @@ public final class RoleTest {
      */
     @Test
     public void testJacksonDeserializable() throws Exception {
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
         ObjectNode node = m.createObjectNode();
         node.put("id", UUID.randomUUID().toString());
-        node.put("createdDate", new Date().getTime());
-        node.put("modifiedDate", new Date().getTime());
+        node.put("createdDate",
+                format.format(Calendar.getInstance().getTime()));
+        node.put("modifiedDate",
+                format.format(Calendar.getInstance().getTime()));
         node.put("name", "name");
 
         String output = m.writeValueAsString(node);
@@ -178,11 +188,11 @@ public final class RoleTest {
                 c.getId().toString(),
                 node.get("id").asText());
         Assert.assertEquals(
-                c.getCreatedDate().getTime(),
-                node.get("createdDate").asLong());
+                format.format(c.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
         Assert.assertEquals(
-                c.getModifiedDate().getTime(),
-                node.get("modifiedDate").asLong());
+                format.format(c.getModifiedDate().getTime()),
+                node.get("modifiedDate").asText());
 
         Assert.assertEquals(
                 c.getName(),

--- a/src/test/java/net/krotscheck/features/database/entity/UserIdentityTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/UserIdentityTest.java
@@ -23,11 +23,17 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import net.krotscheck.features.database.entity.UserIdentity.Deserializer;
+import net.krotscheck.features.jackson.ObjectMapperFactory;
+import net.krotscheck.test.JacksonUtil;
+import org.glassfish.hk2.api.ServiceLocator;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.text.DateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -148,8 +154,8 @@ public final class UserIdentityTest {
 
         UserIdentity identity = new UserIdentity();
         identity.setId(UUID.randomUUID());
-        identity.setCreatedDate(new Date());
-        identity.setModifiedDate(new Date());
+        identity.setCreatedDate(Calendar.getInstance());
+        identity.setModifiedDate(Calendar.getInstance());
         identity.setAuthenticator(authenticator);
         identity.setUser(user);
         identity.setTokens(tokens);
@@ -157,7 +163,8 @@ public final class UserIdentityTest {
         identity.setRemoteId("remoteId");
 
         // De/serialize to json.
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
         String output = m.writeValueAsString(identity);
         JsonNode node = m.readTree(output);
 
@@ -165,11 +172,11 @@ public final class UserIdentityTest {
                 identity.getId().toString(),
                 node.get("id").asText());
         Assert.assertEquals(
-                identity.getCreatedDate().getTime(),
-                node.get("createdDate").asLong());
+                format.format(identity.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
         Assert.assertEquals(
-                identity.getModifiedDate().getTime(),
-                node.get("modifiedDate").asLong());
+                format.format(identity.getCreatedDate().getTime()),
+                node.get("modifiedDate").asText());
 
         Assert.assertEquals(
                 identity.getAuthenticator().getId().toString(),
@@ -208,11 +215,14 @@ public final class UserIdentityTest {
      */
     @Test
     public void testJacksonDeserializable() throws Exception {
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
         ObjectNode node = m.createObjectNode();
         node.put("id", UUID.randomUUID().toString());
-        node.put("createdDate", new Date().getTime());
-        node.put("modifiedDate", new Date().getTime());
+        node.put("createdDate",
+                format.format(Calendar.getInstance().getTime()));
+        node.put("modifiedDate",
+                format.format(Calendar.getInstance().getTime()));
         node.put("remoteId", "remoteId");
 
         ObjectNode claimNode = m.createObjectNode();
@@ -227,11 +237,11 @@ public final class UserIdentityTest {
                 a.getId().toString(),
                 node.get("id").asText());
         Assert.assertEquals(
-                a.getCreatedDate().getTime(),
-                node.get("createdDate").asLong());
+                format.format(a.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
         Assert.assertEquals(
-                a.getModifiedDate().getTime(),
-                node.get("modifiedDate").asLong());
+                format.format(a.getModifiedDate().getTime()),
+                node.get("modifiedDate").asText());
 
         Assert.assertEquals(
                 a.getRemoteId(),

--- a/src/test/java/net/krotscheck/features/database/entity/UserTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/UserTest.java
@@ -23,11 +23,15 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import net.krotscheck.features.database.entity.User.Deserializer;
+import net.krotscheck.test.JacksonUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.text.DateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -85,7 +89,8 @@ public final class UserTest {
     }
 
     /**
-     * Assert that this entity can be serialized into a JSON object, and doesn't
+     * Assert that this entity can be serialized into a JSON object, and
+     * doesn't
      * carry an unexpected payload.
      *
      * @throws Exception Should not be thrown.
@@ -105,14 +110,15 @@ public final class UserTest {
 
         User user = new User();
         user.setId(UUID.randomUUID());
-        user.setCreatedDate(new Date());
-        user.setModifiedDate(new Date());
+        user.setCreatedDate(Calendar.getInstance());
+        user.setModifiedDate(Calendar.getInstance());
         user.setApplication(application);
         user.setRole(role);
         user.setIdentities(identities);
 
         // De/serialize to json.
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
         String output = m.writeValueAsString(user);
         JsonNode node = m.readTree(output);
 
@@ -120,11 +126,11 @@ public final class UserTest {
                 user.getId().toString(),
                 node.get("id").asText());
         Assert.assertEquals(
-                user.getCreatedDate().getTime(),
-                node.get("createdDate").asLong());
+                format.format(user.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
         Assert.assertEquals(
-                user.getModifiedDate().getTime(),
-                node.get("modifiedDate").asLong());
+                format.format(user.getModifiedDate().getTime()),
+                node.get("modifiedDate").asText());
 
         Assert.assertEquals(
                 user.getRole().getId().toString(),
@@ -152,11 +158,14 @@ public final class UserTest {
      */
     @Test
     public void testJacksonDeserializable() throws Exception {
-        ObjectMapper m = new ObjectMapper();
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
         ObjectNode node = m.createObjectNode();
         node.put("id", UUID.randomUUID().toString());
-        node.put("createdDate", new Date().getTime());
-        node.put("modifiedDate", new Date().getTime());
+        node.put("createdDate",
+                format.format(Calendar.getInstance().getTime()));
+        node.put("modifiedDate",
+                format.format(Calendar.getInstance().getTime()));
 
         String output = m.writeValueAsString(node);
         User user = m.readValue(output, User.class);
@@ -165,11 +174,11 @@ public final class UserTest {
                 user.getId().toString(),
                 node.get("id").asText());
         Assert.assertEquals(
-                user.getCreatedDate().getTime(),
-                node.get("createdDate").asLong());
+                format.format(user.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
         Assert.assertEquals(
-                user.getModifiedDate().getTime(),
-                node.get("modifiedDate").asLong());
+                format.format(user.getModifiedDate().getTime()),
+                node.get("modifiedDate").asText());
     }
 
 

--- a/src/test/java/net/krotscheck/test/JacksonUtil.java
+++ b/src/test/java/net/krotscheck/test/JacksonUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.krotscheck.features.jackson.ObjectMapperFactory;
+import org.glassfish.hk2.api.ServiceLocator;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Jackson utility.
+ *
+ * @author Michael Krotscheck
+ */
+public final class JacksonUtil {
+
+    /**
+     * Utility class, private constructor.
+     */
+    private JacksonUtil() {
+    }
+
+    /**
+     * Generate an object mapper as used by the application itself.
+     *
+     * @return A new, simple object mapper.
+     */
+    public static ObjectMapper buildMapper() {
+        return new ObjectMapperFactory(mock(ServiceLocator.class)).provide();
+    }
+}


### PR DESCRIPTION
The data object is mostly deprecated, this switches to using the
calendar object. Furthermore, the patch switches to serializing/deserializing
date/time values as ISO8601 instead of timestamps, as those are more
frequently used by browsers.