### PR TITLE
OAuth Token Types can now be linked to each other.

### DIFF
--- a/src/main/java/net/krotscheck/features/database/entity/OAuthToken.java
+++ b/src/main/java/net/krotscheck/features/database/entity/OAuthToken.java
@@ -63,6 +63,14 @@ public final class OAuthToken extends AbstractEntity {
     private Client client;
 
     /**
+     * The parent auth token (used for refresh tokens only).
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "authToken", nullable = true, updatable = false)
+    @JsonIgnore
+    private OAuthToken authToken;
+
+    /**
      * The token type.
      */
     @Enumerated(EnumType.STRING)
@@ -126,6 +134,24 @@ public final class OAuthToken extends AbstractEntity {
      */
     public void setClient(final Client client) {
         this.client = client;
+    }
+
+    /**
+     * Retrieve the oauth token for this refresh token.
+     *
+     * @return The auth token.
+     */
+    public OAuthToken getAuthToken() {
+        return authToken;
+    }
+
+    /**
+     * Set the new parent auth token (for refresh tokens only).
+     *
+     * @param authToken The new auth token.
+     */
+    public void setAuthToken(final OAuthToken authToken) {
+        this.authToken = authToken;
     }
 
     /**

--- a/src/main/resources/liquibase/db.changelog-1.0.0.yaml
+++ b/src/main/resources/liquibase/db.changelog-1.0.0.yaml
@@ -791,7 +791,7 @@ databaseChangeLog:
           baseColumnNames: authToken
           baseTableName: oauth_tokens
           constraintName: fk_oauth_tokens_oauth_tokens_authToken
-          onDelete: CASCADE
+          onDelete: SET NULL
           onUpdate: CASCADE
           referencedColumnNames: id
           referencedTableName: oauth_tokens

--- a/src/test/java/net/krotscheck/features/database/entity/OAuthTokenTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/OAuthTokenTest.java
@@ -103,6 +103,20 @@ public final class OAuthTokenTest {
     }
 
     /**
+     * Test setting a related token (such as an access token for a refresh
+     * token).
+     */
+    @Test
+    public void testGetSetToken() {
+        OAuthToken token = new OAuthToken();
+        OAuthToken otherToken = new OAuthToken();
+
+        Assert.assertNull(token.getAuthToken());
+        token.setAuthToken(otherToken);
+        Assert.assertEquals(otherToken, token.getAuthToken());
+    }
+
+    /**
      * Test get/set scope list.
      */
     @Test


### PR DESCRIPTION
This is to support refresh tokens that are associated with a specific
access token, both of which need to be removed.