### PR TITLE
Link application scope to authenticator scope.

### DIFF
--- a/src/main/java/net/krotscheck/features/database/entity/AuthenticatorState.java
+++ b/src/main/java/net/krotscheck/features/database/entity/AuthenticatorState.java
@@ -200,22 +200,22 @@ public final class AuthenticatorState extends AbstractEntity {
     }
 
     /**
-     * Get the list of scopes which this request would like to have.
+     * Retreive the scope received from the client.
      *
-     * @return A map of scopes.
+     * @return The client's scope.
      */
     public SortedMap<String, ApplicationScope> getClientScope() {
         return clientScope;
     }
 
     /**
-     * Set the scopes for this authentication request.
+     * Store the scope received from the client.
      *
-     * @param scopes A new map of scopes.
+     * @param clientScope A new client scope.
      */
     public void setClientScope(
-            final SortedMap<String, ApplicationScope> scopes) {
-        this.clientScope = new TreeMap<>(scopes);
+            final SortedMap<String, ApplicationScope> clientScope) {
+        this.clientScope = new TreeMap<>(clientScope);
     }
 
     /**

--- a/src/test/java/net/krotscheck/features/database/entity/AuthenticatorStateTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/AuthenticatorStateTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.SortedMap;
@@ -127,15 +126,14 @@ public final class AuthenticatorStateTest {
     }
 
     /**
-     * Assert that we can get and set client nonce.
+     * Test get/set scope list.
      */
     @Test
-    public void testGetSetClientScope() {
+    public void testGetSetScopes() {
         AuthenticatorState state = new AuthenticatorState();
         SortedMap<String, ApplicationScope> scopes = new TreeMap<>();
         scopes.put("test", new ApplicationScope());
 
-        // Default
         Assert.assertNull(state.getClientScope());
         state.setClientScope(scopes);
         Assert.assertEquals(scopes, state.getClientScope());


### PR DESCRIPTION
This way we can keep track of the scope requested for a token request.