### PR TITLE
ValidationUtil throws exception if invalid grant requested

### DIFF
--- a/src/main/java/net/krotscheck/api/oauth/util/ValidationUtil.java
+++ b/src/main/java/net/krotscheck/api/oauth/util/ValidationUtil.java
@@ -159,10 +159,9 @@ public final class ValidationUtil {
         // Reduce the valid scope list down by the original scopes.
         SortedMap<String, ApplicationScope> results = new TreeMap<>();
         for (String scope : requestedScopes) {
-            if (validScopes.containsKey(scope)) {
-                if (!originalScopes.containsKey(scope)) {
-                    throw new InvalidScopeException();
-                }
+            if (!originalScopes.containsKey(scope)) {
+                throw new InvalidScopeException();
+            } else if (validScopes.containsKey(scope)) {
                 results.put(scope, validScopes.get(scope));
             }
         }


### PR DESCRIPTION
In a revalidation request, if a user requests a grant type
that has not previously been granted, the utility will throw
an exception before the grant type is checked against a valid
field list.