### PR TITLE
Authenticator State persistence is more flexible

### DIFF
--- a/src/main/resources/liquibase/db.changelog-1.0.0.yaml
+++ b/src/main/resources/liquibase/db.changelog-1.0.0.yaml
@@ -515,25 +515,13 @@ databaseChangeLog:
                 constraints:
                   nullable: false
             - column:
-                name: authenticatorState
-                type: varchar(255)
-                constraints:
-                  nullable: false
-                  unique: true
-            - column:
-                name: authenticatorNonce
-                type: varchar(255)
-                constraints:
-                  nullable: false
-                  unique: true
-            - column:
                 name: clientState
                 type: varchar(255)
                 constraints:
                   nullable: false
                   unique: true
             - column:
-                name: clientNonce
+                name: clientRedirect
                 type: varchar(255)
                 constraints:
                   nullable: false
@@ -544,13 +532,6 @@ databaseChangeLog:
               name: clientState
               type: varchar(255)
           indexName: idx_authenticator_states_client_state
-          tableName: authenticator_states
-      - createIndex:
-          columns:
-          - column:
-              name: authenticatorState
-              type: varchar(255)
-          indexName: idx_authenticator_states_authenticator_state
           tableName: authenticator_states
       - addForeignKeyConstraint:
           baseColumnNames: authenticator
@@ -569,12 +550,61 @@ databaseChangeLog:
           referencedColumnNames: id
           referencedTableName: clients
 
-      # An authenticator state should list some scopes which it is applying for.
+      # An authenticator may cache between-request information in this table.
+      # This could include things like nonces, timestamps, encryption keys,
+      # or more.
+      - createTable:
+          tableName: authenticator_state_params
+          columns:
+            - column:
+                name: authenticator_state
+                type: BINARY(16)
+                constraints:
+                  nullable: false
+            - column:
+                name: name
+                type: varchar(255)
+                constraints:
+                  nullable: false
+            - column:
+                name: value
+                type: varchar(255)
+                constraints:
+                  nullable: true
+      - createIndex:
+          columns:
+          - column:
+              name: authenticator_state
+              type: varchar(255)
+          indexName: idx_authenticator_state_params_authenticator_state
+          tableName: authenticator_state_params
+      - createIndex:
+          columns:
+          - column:
+              name: name
+              type: varchar(255)
+          indexName: idx_authenticator_state_params_name
+          tableName: authenticator_state_params
+      - addUniqueConstraint:
+          columnNames: authenticator_state, name
+          constraintName: uq_authenticator_state_params_authenticator_state_name
+          tableName: authenticator_state_params
+      - addForeignKeyConstraint:
+          baseColumnNames: authenticator_state
+          baseTableName: authenticator_state_params
+          constraintName: fk_authenticator_state_params_authenticators
+          onDelete: CASCADE
+          onUpdate: CASCADE
+          referencedColumnNames: id
+          referencedTableName: authenticator_states
+
+      # An intermediate authenticator state must keep track of the requested
+      # scopes.
       - createTable:
           tableName: authenticator_state_scopes
           columns:
             - column:
-                name: state
+                name: authenticator_state
                 type: BINARY(16)
                 constraints:
                   nullable: false
@@ -586,9 +616,9 @@ databaseChangeLog:
       - createIndex:
           columns:
           - column:
-              name: state
+              name: authenticator_state
               type: BINARY(16)
-          indexName: idx_authenticator_state_scopes_state
+          indexName: idx_authenticator_state_scopes_authenticator_state
           tableName: authenticator_state_scopes
       - createIndex:
           columns:
@@ -606,15 +636,15 @@ databaseChangeLog:
           referencedColumnNames: id
           referencedTableName: application_scopes
       - addForeignKeyConstraint:
-          baseColumnNames: state
+          baseColumnNames: authenticator_state
           baseTableName: authenticator_state_scopes
-          constraintName: fk_authenticator_state_scopes_state
+          constraintName: fk_authenticator_state_scopes_authenticator_state
           onDelete: CASCADE
           onUpdate: CASCADE
           referencedColumnNames: id
           referencedTableName: authenticator_states
       - addUniqueConstraint:
-          columnNames: state, scope
+          columnNames: authenticator_state, scope
           constraintName: uq_authenticator_state_scopes_authenticator_state_scopes
           tableName: authenticator_state_scopes
 
@@ -857,6 +887,8 @@ databaseChangeLog:
             tableName: user_identities
         - dropTable:
             tableName: authenticator_state_scopes
+        - dropTable:
+            tableName: authenticator_state_params
         - dropTable:
             tableName: authenticator_states
         - dropTable:

--- a/src/test/java/net/krotscheck/features/database/entity/AuthenticatorStateTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/AuthenticatorStateTest.java
@@ -17,28 +17,13 @@
 
 package net.krotscheck.features.database.entity;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
-import net.krotscheck.features.database.entity.AuthenticatorState.Deserializer;
-import net.krotscheck.test.JacksonUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.text.DateFormat;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Iterator;
-import java.util.List;
+import java.net.URI;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.UUID;
-
-import static org.mockito.Mockito.mock;
+import javax.ws.rs.core.UriBuilder;
 
 /**
  * Unit tests for the AuthenticatorState entity.
@@ -74,32 +59,6 @@ public final class AuthenticatorStateTest {
     }
 
     /**
-     * Assert that we can get and set authenticator state.
-     */
-    @Test
-    public void testGetSetAuthenticatorState() {
-        AuthenticatorState state = new AuthenticatorState();
-
-        // Default
-        Assert.assertNull(state.getAuthenticatorState());
-        state.setAuthenticatorState("state");
-        Assert.assertEquals("state", state.getAuthenticatorState());
-    }
-
-    /**
-     * Assert that we can get and set authenticator nonce.
-     */
-    @Test
-    public void testGetSetAuthenticatorNonce() {
-        AuthenticatorState state = new AuthenticatorState();
-
-        // Default
-        Assert.assertNull(state.getAuthenticatorNonce());
-        state.setAuthenticatorNonce("nonce");
-        Assert.assertEquals("nonce", state.getAuthenticatorNonce());
-    }
-
-    /**
      * Assert that we can get and set client state.
      */
     @Test
@@ -113,16 +72,17 @@ public final class AuthenticatorStateTest {
     }
 
     /**
-     * Assert that we can get and set client nonce.
+     * Assert that we can get and set client redirect.
      */
     @Test
-    public void testGetSetClientNonce() {
+    public void testGetSetClientRedirect() {
         AuthenticatorState state = new AuthenticatorState();
+        URI testUri = UriBuilder.fromUri("http://valid.example.com/").build();
 
         // Default
-        Assert.assertNull(state.getClientNonce());
-        state.setClientNonce("nonce");
-        Assert.assertEquals("nonce", state.getClientNonce());
+        Assert.assertNull(state.getClientRedirect());
+        state.setClientRedirect(testUri);
+        Assert.assertEquals(testUri, state.getClientRedirect());
     }
 
     /**
@@ -134,147 +94,27 @@ public final class AuthenticatorStateTest {
         SortedMap<String, ApplicationScope> scopes = new TreeMap<>();
         scopes.put("test", new ApplicationScope());
 
-        Assert.assertNull(state.getClientScope());
-        state.setClientScope(scopes);
-        Assert.assertEquals(scopes, state.getClientScope());
-        Assert.assertNotSame(scopes, state.getClientScope());
+        Assert.assertNull(state.getClientScopes());
+        state.setClientScopes(scopes);
+        Assert.assertEquals(scopes, state.getClientScopes());
+        Assert.assertNotSame(scopes, state.getClientScopes());
     }
 
     /**
-     * Assert that this entity can be serialized into a JSON object, and
-     * doesn't
-     * carry an unexpected payload.
-     *
-     * @throws Exception Should not be thrown.
+     * Assert that we can get and set client redirect.
      */
     @Test
-    public void testJacksonSerializable() throws Exception {
-        Authenticator authenticator = new Authenticator();
-        authenticator.setId(UUID.randomUUID());
-
-        Client client = new Client();
-        client.setId(UUID.randomUUID());
-
+    public void testGetSetParams() {
         AuthenticatorState state = new AuthenticatorState();
-        state.setId(UUID.randomUUID());
-        state.setCreatedDate(Calendar.getInstance());
-        state.setModifiedDate(Calendar.getInstance());
-        state.setAuthenticator(authenticator);
-        state.setClient(client);
-        state.setAuthenticatorState("authenticatorState");
-        state.setAuthenticatorNonce("authenticatorNonce");
-        state.setClientState("clientState");
-        state.setClientNonce("clientNonce");
 
-        // De/serialize to json.
-        ObjectMapper m = JacksonUtil.buildMapper();
-        DateFormat format = new ISO8601DateFormat();
-        String output = m.writeValueAsString(state);
-        JsonNode node = m.readTree(output);
+        SortedMap<String, String> params = new TreeMap<>();
+        params.put("one", "two");
+        params.put("three", "four");
 
-        Assert.assertEquals(
-                state.getId().toString(),
-                node.get("id").asText());
-        Assert.assertEquals(
-                format.format(state.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
-        Assert.assertEquals(
-                format.format(state.getCreatedDate().getTime()),
-                node.get("modifiedDate").asText());
-
-        Assert.assertEquals(
-                state.getAuthenticator().getId().toString(),
-                node.get("authenticator").asText());
-        Assert.assertEquals(
-                state.getClient().getId().toString(),
-                node.get("client").asText());
-        Assert.assertEquals(
-                state.getAuthenticatorState(),
-                node.get("authenticatorState").asText());
-        Assert.assertEquals(
-                state.getAuthenticatorNonce(),
-                node.get("authenticatorNonce").asText());
-        Assert.assertEquals(
-                state.getClientState(),
-                node.get("clientState").asText());
-        Assert.assertEquals(
-                state.getClientNonce(),
-                node.get("clientNonce").asText());
-
-        // Enforce a given number of items.
-        List<String> names = new ArrayList<>();
-        Iterator<String> nameIterator = node.fieldNames();
-        while (nameIterator.hasNext()) {
-            names.add(nameIterator.next());
-        }
-        Assert.assertEquals(9, names.size());
-    }
-
-    /**
-     * Assert that this entity can be deserialized from a JSON object.
-     *
-     * @throws Exception Should not be thrown.
-     */
-    @Test
-    public void testJacksonDeserializable() throws Exception {
-        ObjectMapper m = JacksonUtil.buildMapper();
-        DateFormat format = new ISO8601DateFormat();
-        ObjectNode node = m.createObjectNode();
-        node.put("id", UUID.randomUUID().toString());
-        node.put("createdDate",
-                format.format(Calendar.getInstance().getTime()));
-        node.put("modifiedDate",
-                format.format(Calendar.getInstance().getTime()));
-        node.put("authenticatorState", "authenticatorState");
-        node.put("authenticatorNonce", "authenticatorNonce");
-        node.put("clientState", "clientState");
-        node.put("clientNonce", "clientNonce");
-        node.put("clientScope", "clientScope");
-
-        String output = m.writeValueAsString(node);
-        AuthenticatorState c = m.readValue(output, AuthenticatorState.class);
-
-        Assert.assertEquals(
-                c.getId().toString(),
-                node.get("id").asText());
-        Assert.assertEquals(
-                format.format(c.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
-        Assert.assertEquals(
-                format.format(c.getModifiedDate().getTime()),
-                node.get("modifiedDate").asText());
-
-        Assert.assertEquals(
-                c.getAuthenticatorState(),
-                node.get("authenticatorState").asText());
-        Assert.assertEquals(
-                c.getAuthenticatorNonce(),
-                node.get("authenticatorNonce").asText());
-        Assert.assertEquals(
-                c.getClientState(),
-                node.get("clientState").asText());
-        Assert.assertEquals(
-                c.getClientNonce(),
-                node.get("clientNonce").asText());
-    }
-
-    /**
-     * Test the deserializer.
-     *
-     * @throws Exception Should not be thrown.
-     */
-    @Test
-    public void testDeserializeSimple() throws Exception {
-        UUID uuid = UUID.randomUUID();
-        String id = String.format("\"%s\"", uuid);
-        JsonFactory f = new JsonFactory();
-        JsonParser preloadedParser = f.createParser(id);
-        preloadedParser.nextToken(); // Advance to the first value.
-
-        Deserializer deserializer = new Deserializer();
-        AuthenticatorState c = deserializer.deserialize(preloadedParser,
-                mock(DeserializationContext.class));
-
-        Assert.assertEquals(uuid, c.getId());
+        // Default
+        Assert.assertNull(state.getAuthenticatorStateParams());
+        state.setAuthenticatorStateParams(params);
+        Assert.assertEquals(params, state.getAuthenticatorStateParams());
+        Assert.assertNotSame(params, state.getAuthenticatorStateParams());
     }
 }


### PR DESCRIPTION
As we cannot anticipate the parameters which an authenticator
may need to persist between requests, this patch expands on the
previous explicit fields and allows the creation of simple key/value
mappings.

Furthermore, as this entity should never be deserialized, all JSON
references have been removed.