### PR TITLE
Users do not necessarily have roles.

### DIFF
--- a/src/main/java/net/krotscheck/features/database/entity/User.java
+++ b/src/main/java/net/krotscheck/features/database/entity/User.java
@@ -58,7 +58,7 @@ public final class User extends AbstractEntity {
      * The user's role in this application.
      */
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "role", nullable = false, updatable = true)
+    @JoinColumn(name = "role", nullable = true, updatable = true)
     @JsonIdentityReference(alwaysAsId = true)
     @JsonDeserialize(using = Role.Deserializer.class)
     private Role role;

--- a/src/main/resources/liquibase/db.changelog-1.0.0.yaml
+++ b/src/main/resources/liquibase/db.changelog-1.0.0.yaml
@@ -202,7 +202,7 @@ databaseChangeLog:
                 name: role
                 type: BINARY(16)
                 constraints:
-                  nullable: false
+                  nullable: true
       - addForeignKeyConstraint:
           baseColumnNames: application
           baseTableName: users


### PR DESCRIPTION
Roles are what inform which scopes are permitted per user, and
scopes are optional. By reference, roles should also be optional,
with the default behavior being "Yes we know who you are, but no
you can't have any scope".