### PR TITLE
AuthenticatorState does not necessarily have a state.

### DIFF
--- a/src/main/java/net/krotscheck/features/database/entity/AuthenticatorState.java
+++ b/src/main/java/net/krotscheck/features/database/entity/AuthenticatorState.java
@@ -65,12 +65,12 @@ public final class AuthenticatorState extends AbstractEntity {
     /**
      * The client's state.
      */
-    @Basic(optional = false)
+    @Basic
     @Column(name = "clientState", unique = false)
     private String clientState;
 
     /**
-     * The client's state.
+     * The client's redirect.
      */
     @Basic(optional = false)
     @Column(name = "clientRedirect", unique = false)

--- a/src/main/resources/liquibase/db.changelog-1.0.0.yaml
+++ b/src/main/resources/liquibase/db.changelog-1.0.0.yaml
@@ -518,14 +518,12 @@ databaseChangeLog:
                 name: clientState
                 type: varchar(255)
                 constraints:
-                  nullable: false
-                  unique: true
+                  nullable: true
             - column:
                 name: clientRedirect
                 type: varchar(255)
                 constraints:
                   nullable: false
-                  unique: true
       - createIndex:
           columns:
           - column:


### PR DESCRIPTION
The state parameter is optional in the RFC, this relaxes this
constraint in the database.