### PR TITLE
Created Authentication Contract

### DIFF
--- a/src/main/java/net/krotscheck/api/oauth/authenticator/IAuthenticator.java
+++ b/src/main/java/net/krotscheck/api/oauth/authenticator/IAuthenticator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.api.oauth.authenticator;
+
+import net.krotscheck.features.database.entity.Authenticator;
+import net.krotscheck.features.database.entity.UserIdentity;
+
+import java.net.URI;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * This interface describes the methods used during user authentication,
+ * responsible for interfacing with a third party authentication provider.
+ * All authentication MUST be performed via redirect.
+ *
+ * @author Michael Krotscheck
+ */
+public interface IAuthenticator {
+
+    /**
+     * Execute an authentication process for a specific request.
+     *
+     * @param configuration The authenticator configuration.
+     * @param callback      The redirect, on this server, where the response
+     *                      should go.
+     * @return An HTTP response, redirecting the client to the next step.
+     */
+    Response authenticate(Authenticator configuration,
+                          URI callback);
+
+    /**
+     * Resolve and/or create a user identity for a specific client, given the
+     * returned URI.
+     *
+     * @param configuration    The authenticator configuration.
+     * @param callbackResponse The URI received via the callback mechanism.
+     * @return A user identity.
+     */
+    UserIdentity callback(Authenticator configuration,
+                          UriInfo callbackResponse);
+}

--- a/src/main/java/net/krotscheck/api/oauth/authenticator/package-info.java
+++ b/src/main/java/net/krotscheck/api/oauth/authenticator/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Authentication handlers.
+ */
+package net.krotscheck.api.oauth.authenticator;

--- a/src/test/java/net/krotscheck/api/oauth/authenticator/TestAuthenticator.java
+++ b/src/test/java/net/krotscheck/api/oauth/authenticator/TestAuthenticator.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.api.oauth.authenticator;
+
+import net.krotscheck.features.database.entity.Authenticator;
+import net.krotscheck.features.database.entity.User;
+import net.krotscheck.features.database.entity.UserIdentity;
+import org.apache.http.HttpStatus;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.process.internal.RequestScoped;
+import org.hibernate.Criteria;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.criterion.Restrictions;
+
+import java.net.URI;
+import java.util.List;
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * The dev authenticator provides a simple authenticator implementation which
+ * may be used when building a new application and debugging the
+ * authentication flow. It only ever creates a single user, "Pat Developer",
+ * and always presumes a successful third-party authentication.
+ *
+ * @author Michael Krotscheck
+ */
+public final class TestAuthenticator implements IAuthenticator {
+
+    /**
+     * Unique foreign ID string for the debug user.
+     */
+    private static final String REMOTE_ID = "dev_user";
+
+    /**
+     * Hibernate session, to use for database access.
+     */
+    private final Session session;
+
+    /**
+     * Create a new dev authenticator.
+     *
+     * @param session Injected hibernate session.
+     */
+    @Inject
+    public TestAuthenticator(final Session session) {
+        this.session = session;
+    }
+
+
+    /**
+     * Execute an authentication process for a specific request.
+     *
+     * @param configuration The authenticator configuration.
+     * @param callback      The redirect, on this server, where the response
+     *                      should go.
+     * @return An HTTP response, redirecting the client to the next step.
+     */
+    @Override
+    public Response authenticate(final Authenticator configuration,
+                                 final URI callback) {
+        return Response
+                .status(HttpStatus.SC_MOVED_TEMPORARILY)
+                .location(callback)
+                .build();
+    }
+
+    /**
+     * Resolve and/or create a user identity, given an intermediate state and
+     * request parameters.
+     *
+     * @param authenticator    The authenticator configuration.
+     * @param callbackResponse The URI received via the callback mechanism.
+     */
+    @Override
+    public UserIdentity callback(final Authenticator authenticator,
+                                 final UriInfo callbackResponse) {
+
+        Criteria searchCriteria = session.createCriteria(UserIdentity.class);
+        searchCriteria.add(Restrictions.eq("authenticator", authenticator));
+        searchCriteria.add(Restrictions.eq("remoteId", REMOTE_ID));
+        searchCriteria.setFirstResult(0);
+        searchCriteria.setMaxResults(1);
+        List<UserIdentity> results = searchCriteria.list();
+
+        // Do we need to create a new user?
+        if (results.size() == 0) {
+            User devUser = new User();
+            devUser.setApplication(authenticator.getClient().getApplication());
+
+            UserIdentity identity = new UserIdentity();
+            identity.setAuthenticator(authenticator);
+            identity.setRemoteId(REMOTE_ID);
+            identity.setUser(devUser);
+
+            Transaction t = session.beginTransaction();
+            session.save(devUser);
+            session.save(identity);
+            t.commit();
+
+            return identity;
+        }
+
+        return results.get(0);
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bind(TestAuthenticator.class)
+                    .to(IAuthenticator.class)
+                    .named("test")
+                    .in(RequestScoped.class);
+        }
+    }
+}

--- a/src/test/java/net/krotscheck/api/oauth/authenticator/package-info.java
+++ b/src/test/java/net/krotscheck/api/oauth/authenticator/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test classes related to authentication.
+ */
+package net.krotscheck.api.oauth.authenticator;


### PR DESCRIPTION
This interface describes the api contract which third party auth
providers should implement. It also provides a very simple 'test'
authenticator, which may be used in unit tests.