### PR TITLE
OAuthToken adds redirect

### DIFF
--- a/src/main/java/net/krotscheck/features/database/entity/OAuthToken.java
+++ b/src/main/java/net/krotscheck/features/database/entity/OAuthToken.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import net.krotscheck.features.database.deserializer.AbstractEntityReferenceDeserializer;
 import org.hibernate.annotations.SortNatural;
 
+import java.net.URI;
 import java.util.Calendar;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -84,6 +85,14 @@ public final class OAuthToken extends AbstractEntity {
     @Basic(optional = false)
     @Column(name = "expiresIn", nullable = false)
     private long expiresIn = 600;
+
+    /**
+     * Authorization Codes must keep track of the redirect they were issued
+     * for.
+     */
+    @Basic
+    @Column(name = "redirect", nullable = true)
+    private URI redirect;
 
     /**
      * List of the application's scopes.
@@ -225,6 +234,24 @@ public final class OAuthToken extends AbstractEntity {
         Calendar expireDate = (Calendar) getCreatedDate().clone();
         expireDate.add(Calendar.SECOND, (int) getExpiresIn());
         return now.after(expireDate);
+    }
+
+    /**
+     * Get the redirect attached to this token.
+     *
+     * @return The redirect.
+     */
+    public URI getRedirect() {
+        return redirect;
+    }
+
+    /**
+     * Set the redirect for this particular token.
+     *
+     * @param redirect The new redirect.
+     */
+    public void setRedirect(final URI redirect) {
+        this.redirect = redirect;
     }
 
     /**

--- a/src/main/resources/liquibase/db.changelog-1.0.0.yaml
+++ b/src/main/resources/liquibase/db.changelog-1.0.0.yaml
@@ -799,6 +799,11 @@ databaseChangeLog:
                 type: int
                 constraints:
                   nullable: false
+            - column:
+                name: redirect
+                type: varchar(255)
+                constraints:
+                  nullable: false
       - addForeignKeyConstraint:
           baseColumnNames: identity
           baseTableName: oauth_tokens

--- a/src/test/java/net/krotscheck/features/database/entity/OAuthTokenTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/OAuthTokenTest.java
@@ -29,6 +29,7 @@ import net.krotscheck.test.JacksonUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.net.URI;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -115,6 +116,22 @@ public final class OAuthTokenTest {
     }
 
     /**
+     * Test setting the redirection URL.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testGetSetRedirect() throws Exception {
+        OAuthToken token = new OAuthToken();
+
+        URI test = new URI("http://example.com/");
+
+        Assert.assertNull(token.getRedirect());
+        token.setRedirect(test);
+        Assert.assertEquals(test, token.getRedirect());
+    }
+
+    /**
      * Test get/set scope list.
      */
     @Test
@@ -187,6 +204,7 @@ public final class OAuthTokenTest {
         token.setModifiedDate(Calendar.getInstance());
         token.setIdentity(identity);
         token.setClient(client);
+        token.setRedirect(new URI("http://example.com/"));
         token.setTokenType(OAuthTokenType.Authorization);
         token.setExpiresIn(100);
 
@@ -212,7 +230,9 @@ public final class OAuthTokenTest {
         Assert.assertEquals(
                 token.getExpiresIn(),
                 node.get("expiresIn").asLong());
-
+        Assert.assertEquals(
+                token.getRedirect().toString(),
+                node.get("redirect").asText());
 
         Assert.assertFalse(node.has("client"));
         Assert.assertFalse(node.has("identity"));
@@ -223,7 +243,7 @@ public final class OAuthTokenTest {
         while (nameIterator.hasNext()) {
             names.add(nameIterator.next());
         }
-        Assert.assertEquals(5, names.size());
+        Assert.assertEquals(6, names.size());
     }
 
     /**
@@ -244,6 +264,7 @@ public final class OAuthTokenTest {
         node.put("accessToken", "accessToken");
         node.put("tokenType", "Authorization");
         node.put("expiresIn", 300);
+        node.put("redirect", "http://example.com");
 
         String output = m.writeValueAsString(node);
         OAuthToken c = m.readValue(output, OAuthToken.class);
@@ -264,6 +285,9 @@ public final class OAuthTokenTest {
         Assert.assertEquals(
                 c.getExpiresIn(),
                 node.get("expiresIn").asLong());
+        Assert.assertEquals(
+                c.getRedirect().toString(),
+                node.get("redirect").asText());
     }
 
     /**
@@ -285,5 +309,4 @@ public final class OAuthTokenTest {
 
         Assert.assertEquals(uuid, c.getId());
     }
-
 }


### PR DESCRIPTION
OAuthTokens - actually authorization codes - must keep track of the
redirect for which they've been issued. This adds a database field
to support this.