### PR TITLE
Updated authentication interface

### DIFF
--- a/src/main/java/net/krotscheck/api/oauth/authenticator/AbstractAuthenticator.java
+++ b/src/main/java/net/krotscheck/api/oauth/authenticator/AbstractAuthenticator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.api.oauth.authenticator;
+
+import net.krotscheck.api.oauth.exception.exception.Rfc6749Exception.InvalidRequestException;
+
+import java.util.List;
+import javax.ws.rs.core.MultivaluedMap;
+
+/**
+ * An abstract authenticator, mostly containing utility methods.
+ *
+ * @author Michael Krotscheck
+ */
+public abstract class AbstractAuthenticator implements IAuthenticator {
+
+    /**
+     * This helper method assumes at least, but no more than, one single
+     * value in a MultiValuedMap. If this value exists, it is returned.
+     * Otherwise, it raises an InvalidRequestException.
+     *
+     * @param values The map of values.
+     * @param key    The key to get.
+     * @return The value retrieved, but only if only one exists for this key.
+     * @throws InvalidRequestException Thrown if the value is
+     *                                 not found, or if more than one instance
+     *                                 of the value is
+     *                                 found.
+     */
+    protected final String getOne(final MultivaluedMap<String, String> values,
+                                  final String key)
+            throws InvalidRequestException {
+        List<String> listValues = values.get(key);
+        if (listValues == null) {
+            throw new InvalidRequestException();
+        }
+        if (listValues.size() != 1) {
+            throw new InvalidRequestException();
+        }
+        return listValues.get(0);
+    }
+}

--- a/src/main/java/net/krotscheck/api/oauth/authenticator/IAuthenticator.java
+++ b/src/main/java/net/krotscheck/api/oauth/authenticator/IAuthenticator.java
@@ -21,8 +21,8 @@ import net.krotscheck.features.database.entity.Authenticator;
 import net.krotscheck.features.database.entity.UserIdentity;
 
 import java.net.URI;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
 
 /**
  * This interface describes the methods used during user authentication,
@@ -34,24 +34,26 @@ import javax.ws.rs.core.UriInfo;
 public interface IAuthenticator {
 
     /**
-     * Execute an authentication process for a specific request.
+     * Delegate an authentication request to a third party authentication
+     * provider, such as Google, Facebook, etc.
      *
      * @param configuration The authenticator configuration.
      * @param callback      The redirect, on this server, where the response
      *                      should go.
      * @return An HTTP response, redirecting the client to the next step.
      */
-    Response authenticate(Authenticator configuration,
-                          URI callback);
+    Response delegate(Authenticator configuration,
+                      URI callback);
 
     /**
-     * Resolve and/or create a user identity for a specific client, given the
-     * returned URI.
+     * Authenticate and/or create a user identity for a specific client, given
+     * the URI from an authentication delegate.
      *
-     * @param configuration    The authenticator configuration.
-     * @param callbackResponse The URI received via the callback mechanism.
+     * @param configuration The authenticator configuration.
+     * @param parameters    Parameters for the authenticator, retrieved from
+     *                      an appropriate source.
      * @return A user identity.
      */
-    UserIdentity callback(Authenticator configuration,
-                          UriInfo callbackResponse);
+    UserIdentity authenticate(Authenticator configuration,
+                              MultivaluedMap<String, String> parameters);
 }

--- a/src/test/java/net/krotscheck/api/oauth/authenticator/AbstractAuthenticatorTest.java
+++ b/src/test/java/net/krotscheck/api/oauth/authenticator/AbstractAuthenticatorTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.api.oauth.authenticator;
+
+import net.krotscheck.api.oauth.exception.exception.Rfc6749Exception.InvalidRequestException;
+import net.krotscheck.features.database.entity.Authenticator;
+import net.krotscheck.features.database.entity.UserIdentity;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URI;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+/**
+ * Test the utility methods in the Abstract Authenticator.
+ */
+public final class AbstractAuthenticatorTest {
+
+    /**
+     * Assert that testOne will always return one value.
+     */
+    @Test
+    public void testGetOne() {
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.add("foo", "bar");
+
+        TestAuthenticator t = new TestAuthenticator();
+        String result = t.getOne(params, "foo");
+        Assert.assertEquals("bar", result);
+    }
+
+    /**
+     * Assert that testOne throws an exception if no value exists to retrieve.
+     */
+    @Test(expected = InvalidRequestException.class)
+    public void testGetOneNoValue() {
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+
+        TestAuthenticator t = new TestAuthenticator();
+        t.getOne(params, "does_not_exist");
+    }
+
+    /**
+     * Assert that testOne throws an exception if more than one value exists.
+     */
+    @Test(expected = InvalidRequestException.class)
+    public void testGetOneMultiResult() {
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.add("foo", "one");
+        params.add("foo", "two");
+
+        TestAuthenticator t = new TestAuthenticator();
+        t.getOne(params, "foo");
+    }
+
+
+    private static final class TestAuthenticator extends AbstractAuthenticator {
+
+        /**
+         * Delegate an authentication request to a third party authentication
+         * provider, such as Google, Facebook, etc.
+         *
+         * @param configuration The authenticator configuration.
+         * @param callback      The redirect, on this server, where the
+         *                      response
+         *                      should go.
+         * @return An HTTP response, redirecting the client to the next step.
+         */
+        @Override
+        public Response delegate(final Authenticator configuration,
+                                 final URI callback) {
+            return null; // Do nothing
+        }
+
+        /**
+         * Authenticate and/or create a user identity for a specific client,
+         * given
+         * the URI from an authentication delegate.
+         *
+         * @param configuration The authenticator configuration.
+         * @param parameters    Parameters for the authenticator, retrieved
+         *                      from
+         *                      an appropriate source.
+         * @return A user identity.
+         */
+        @Override
+        public UserIdentity authenticate(final Authenticator configuration,
+                                         final MultivaluedMap<String, String>
+                                                 parameters) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/net/krotscheck/api/oauth/authenticator/TestAuthenticator.java
+++ b/src/test/java/net/krotscheck/api/oauth/authenticator/TestAuthenticator.java
@@ -31,8 +31,8 @@ import org.hibernate.criterion.Restrictions;
 import java.net.URI;
 import java.util.List;
 import javax.inject.Inject;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
 
 /**
  * The dev authenticator provides a simple authenticator implementation which
@@ -42,7 +42,9 @@ import javax.ws.rs.core.UriInfo;
  *
  * @author Michael Krotscheck
  */
-public final class TestAuthenticator implements IAuthenticator {
+public final class TestAuthenticator
+        extends AbstractAuthenticator
+        implements IAuthenticator {
 
     /**
      * Unique foreign ID string for the debug user.
@@ -74,8 +76,8 @@ public final class TestAuthenticator implements IAuthenticator {
      * @return An HTTP response, redirecting the client to the next step.
      */
     @Override
-    public Response authenticate(final Authenticator configuration,
-                                 final URI callback) {
+    public Response delegate(final Authenticator configuration,
+                             final URI callback) {
         return Response
                 .status(HttpStatus.SC_MOVED_TEMPORARILY)
                 .location(callback)
@@ -86,18 +88,22 @@ public final class TestAuthenticator implements IAuthenticator {
      * Resolve and/or create a user identity, given an intermediate state and
      * request parameters.
      *
-     * @param authenticator    The authenticator configuration.
-     * @param callbackResponse The URI received via the callback mechanism.
+     * @param authenticator The authenticator configuration.
+     * @param parameters    Parameters for the authenticator, retrieved from
+     *                      an appropriate source.
      */
     @Override
-    public UserIdentity callback(final Authenticator authenticator,
-                                 final UriInfo callbackResponse) {
+    public UserIdentity authenticate(final Authenticator authenticator,
+                                     final MultivaluedMap<String, String>
+                                             parameters) {
 
         Criteria searchCriteria = session.createCriteria(UserIdentity.class);
+
         searchCriteria.add(Restrictions.eq("authenticator", authenticator));
         searchCriteria.add(Restrictions.eq("remoteId", REMOTE_ID));
         searchCriteria.setFirstResult(0);
         searchCriteria.setMaxResults(1);
+
         List<UserIdentity> results = searchCriteria.list();
 
         // Do we need to create a new user?


### PR DESCRIPTION
This updates the IAuthenticator interface to make a
little more sense from a human perspective. The 'authenticate'
method has been renamed to 'delegate', as this is actually what
it does. The previously named 'callback' method has then been
renamed to 'authenticate'. Additionally, an abstract authenticator
implementation was added.