### PR TITLE
Owner credentials moved into User Identity table

### DIFF
--- a/src/main/java/net/krotscheck/features/database/entity/User.java
+++ b/src/main/java/net/krotscheck/features/database/entity/User.java
@@ -28,8 +28,6 @@ import org.hibernate.search.annotations.IndexedEmbedded;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.Basic;
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
@@ -73,29 +71,6 @@ public final class User extends AbstractEntity {
     @JsonIgnore
     @IndexedEmbedded(includePaths = {"claims"})
     private List<UserIdentity> identities;
-
-    /**
-     * The user's password salt.
-     */
-    @JsonIgnore
-    @Basic
-    @Column(name = "salt", nullable = true, updatable = true)
-    private byte[] salt;
-
-    /**
-     * The user's hashed password.
-     */
-    @JsonIgnore
-    @Basic
-    @Column(name = "password", nullable = true, updatable = true)
-    private byte[] password;
-
-    /**
-     * The user's email/login.
-     */
-    @Basic
-    @Column(name = "email", nullable = true, updatable = true, unique = false)
-    private String email;
 
     /**
      * Get the application this user belongs to.
@@ -149,60 +124,6 @@ public final class User extends AbstractEntity {
      */
     public void setIdentities(final List<UserIdentity> identities) {
         this.identities = new ArrayList<>(identities);
-    }
-
-    /**
-     * Get the salt.
-     *
-     * @return The current salt.
-     */
-    public byte[] getSalt() {
-        return salt;
-    }
-
-    /**
-     * Set a new salt.
-     *
-     * @param salt A new salt, should be 32 characters long.
-     */
-    public void setSalt(final byte[] salt) {
-        this.salt = salt;
-    }
-
-    /**
-     * Get the password.
-     *
-     * @return An encrypted password.
-     */
-    public byte[] getPassword() {
-        return password;
-    }
-
-    /**
-     * Set a new password. Make sure this is encrypted first.
-     *
-     * @param password The new password.
-     */
-    public void setPassword(final byte[] password) {
-        this.password = password;
-    }
-
-    /**
-     * Get an email/login for the user.
-     *
-     * @return The new email.
-     */
-    public String getEmail() {
-        return email;
-    }
-
-    /**
-     * Set the email/login for the user. Must be unique per application.
-     *
-     * @param email A new login.
-     */
-    public void setEmail(final String email) {
-        this.email = email;
     }
 
     /**

--- a/src/main/java/net/krotscheck/features/database/entity/UserIdentity.java
+++ b/src/main/java/net/krotscheck/features/database/entity/UserIdentity.java
@@ -105,6 +105,22 @@ public final class UserIdentity extends AbstractEntity implements Principal {
     private Map<String, String> claims;
 
     /**
+     * The user's password salt.
+     */
+    @JsonIgnore
+    @Basic
+    @Column(name = "salt", nullable = true, updatable = true)
+    private byte[] salt;
+
+    /**
+     * The user's hashed password.
+     */
+    @JsonIgnore
+    @Basic
+    @Column(name = "password", nullable = true, updatable = true)
+    private byte[] password;
+
+    /**
      * Get the user record for this identity.
      *
      * @return The user record.
@@ -203,6 +219,42 @@ public final class UserIdentity extends AbstractEntity implements Principal {
      */
     public void setTokens(final List<OAuthToken> tokens) {
         this.tokens = new ArrayList<>(tokens);
+    }
+
+    /**
+     * Get the salt.
+     *
+     * @return The current salt.
+     */
+    public byte[] getSalt() {
+        return salt;
+    }
+
+    /**
+     * Set a new salt.
+     *
+     * @param salt A new salt, should be 32 characters long.
+     */
+    public void setSalt(final byte[] salt) {
+        this.salt = salt;
+    }
+
+    /**
+     * Get the password.
+     *
+     * @return An encrypted password.
+     */
+    public byte[] getPassword() {
+        return password;
+    }
+
+    /**
+     * Set a new password. Make sure this is encrypted first.
+     *
+     * @param password The new password.
+     */
+    public void setPassword(final byte[] password) {
+        this.password = password;
     }
 
     /**

--- a/src/main/resources/liquibase/db.changelog-1.0.0.yaml
+++ b/src/main/resources/liquibase/db.changelog-1.0.0.yaml
@@ -203,22 +203,6 @@ databaseChangeLog:
                 type: BINARY(16)
                 constraints:
                   nullable: true
-            - column:
-                name: email
-                type: varchar(255)
-                constraints:
-                  nullable: true
-                  unique: true
-            - column:
-                name: salt
-                type: BINARY(32)
-                constraints:
-                  nullable: true
-            - column:
-                name: password
-                type: BINARY(64)
-                constraints:
-                  nullable: true
       - addForeignKeyConstraint:
           baseColumnNames: application
           baseTableName: users
@@ -235,17 +219,6 @@ databaseChangeLog:
           onUpdate: CASCADE
           referencedColumnNames: id
           referencedTableName: roles
-      - createIndex:
-          columns:
-          - column:
-              name: email
-              type: varchar(255)
-          indexName: idx_users_email
-          tableName: users
-      - addUniqueConstraint:
-          columnNames: application, email
-          constraintName: uq_users_application_email
-          tableName: users
 
       # This key constraint locks down owners of applications.
       - addForeignKeyConstraint:
@@ -660,6 +633,16 @@ databaseChangeLog:
                 type: varchar(255)
                 constraints:
                   nullable: false
+            - column:
+                name: password
+                type: BINARY(64)
+                constraints:
+                  nullable: true
+            - column:
+                name: salt
+                type: BINARY(32)
+                constraints:
+                  nullable: true
       - createIndex:
           columns:
           - column:

--- a/src/test/java/net/krotscheck/features/database/entity/UserIdentityTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/UserIdentityTest.java
@@ -25,16 +25,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import net.krotscheck.features.database.entity.UserIdentity.Deserializer;
-import net.krotscheck.features.jackson.ObjectMapperFactory;
 import net.krotscheck.test.JacksonUtil;
-import org.glassfish.hk2.api.ServiceLocator;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.security.SecureRandom;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -130,8 +128,36 @@ public final class UserIdentityTest {
     }
 
     /**
-     * Assert that this entity can be serialized into a JSON object, and doesn't
-     * carry an unexpected payload.
+     * Test the salt.
+     */
+    @Test
+    public void testGetSetSalt() {
+        UserIdentity identity = new UserIdentity();
+        byte[] testBytes = new byte[32];
+        new SecureRandom().nextBytes(testBytes);
+
+        Assert.assertNull(identity.getSalt());
+        identity.setSalt(testBytes);
+        Assert.assertEquals(testBytes, identity.getSalt());
+    }
+
+    /**
+     * Test the Password.
+     */
+    @Test
+    public void testGetSetPassword() {
+        UserIdentity identity = new UserIdentity();
+        byte[] testBytes = new byte[32];
+        new SecureRandom().nextBytes(testBytes);
+
+        Assert.assertNull(identity.getPassword());
+        identity.setPassword(testBytes);
+        Assert.assertEquals(testBytes, identity.getPassword());
+    }
+
+    /**
+     * Assert that this entity can be serialized into a JSON object, and
+     * doesn't carry an unexpected payload.
      *
      * @throws Exception Should not be thrown.
      */
@@ -160,6 +186,8 @@ public final class UserIdentityTest {
         identity.setUser(user);
         identity.setTokens(tokens);
         identity.setClaims(claims);
+        identity.setPassword(new byte[20]);
+        identity.setSalt(new byte[20]);
         identity.setRemoteId("remoteId");
 
         // De/serialize to json.
@@ -198,6 +226,8 @@ public final class UserIdentityTest {
                 claimsNode.get("two").asText());
 
         Assert.assertFalse(node.has("tokens"));
+        Assert.assertFalse(node.has("password"));
+        Assert.assertFalse(node.has("salt"));
 
         // Enforce a given number of items.
         List<String> names = new ArrayList<>();
@@ -276,5 +306,4 @@ public final class UserIdentityTest {
 
         Assert.assertEquals(uuid, u.getId());
     }
-
 }

--- a/src/test/java/net/krotscheck/features/database/entity/UserTest.java
+++ b/src/test/java/net/krotscheck/features/database/entity/UserTest.java
@@ -89,46 +89,6 @@ public final class UserTest {
     }
 
     /**
-     * Test the salt
-     */
-    @Test
-    public void testGetSetSalt() {
-        User user = new User();
-        byte[] testBytes = new byte[32];
-        new SecureRandom().nextBytes(testBytes);
-
-        Assert.assertNull(user.getSalt());
-        user.setSalt(testBytes);
-        Assert.assertEquals(testBytes, user.getSalt());
-    }
-
-    /**
-     * Test the Email
-     */
-    @Test
-    public void testGetSetEmail() {
-        User user = new User();
-
-        Assert.assertNull(user.getEmail());
-        user.setEmail("foo");
-        Assert.assertEquals("foo", user.getEmail());
-    }
-
-    /**
-     * Test the Password
-     */
-    @Test
-    public void testGetSetPassword() {
-        User user = new User();
-        byte[] testBytes = new byte[32];
-        new SecureRandom().nextBytes(testBytes);
-
-        Assert.assertNull(user.getPassword());
-        user.setPassword(testBytes);
-        Assert.assertEquals(testBytes, user.getPassword());
-    }
-
-    /**
      * Assert that this entity can be serialized into a JSON object, and
      * doesn't
      * carry an unexpected payload.


### PR DESCRIPTION
Since most of our authenticators use the UserIdentity table, it makes
sense for us to store a user's credentials (login, salt, password)
there as well. This patch moves the credentials fields into the
identity table directly, since we don't want to put them in claims
(which are search indexed).