### PR TITLE
Created Grant Handler for Client Credentials

### DIFF
--- a/src/main/java/net/krotscheck/api/oauth/OAuthAPI.java
+++ b/src/main/java/net/krotscheck/api/oauth/OAuthAPI.java
@@ -21,6 +21,7 @@ import net.krotscheck.api.oauth.factory.CredentialsFactory;
 import net.krotscheck.api.oauth.filter.ClientAuthorizationFilter;
 import net.krotscheck.api.oauth.resource.AuthorizationService;
 import net.krotscheck.api.oauth.resource.TokenService;
+import net.krotscheck.api.oauth.resource.grant.ClientCredentialsGrantHandler;
 import net.krotscheck.features.config.ConfigurationFeature;
 import net.krotscheck.features.database.DatabaseFeature;
 import net.krotscheck.features.exception.ExceptionFeature;
@@ -55,6 +56,9 @@ public class OAuthAPI extends ResourceConfig {
 
         // Service filters
         register(new ClientAuthorizationFilter.Binder());
+
+        // ResponseType and GrantType handlers
+        register(new ClientCredentialsGrantHandler.Binder());
 
         // Resource services
         register(TokenService.class);

--- a/src/main/java/net/krotscheck/api/oauth/resource/TokenService.java
+++ b/src/main/java/net/krotscheck/api/oauth/resource/TokenService.java
@@ -18,13 +18,27 @@
 package net.krotscheck.api.oauth.resource;
 
 import net.krotscheck.api.oauth.annotation.OAuthFilterChain;
+import net.krotscheck.api.oauth.exception.exception.Rfc6749Exception.InvalidGrantException;
+import net.krotscheck.api.oauth.factory.CredentialsFactory.Credentials;
+import net.krotscheck.api.oauth.resource.grant.IGrantTypeHandler;
+import net.krotscheck.features.database.entity.Client;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.hibernate.Session;
 
 import javax.annotation.security.PermitAll;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
 
 /**
  * The token service for our OAuth2 provider.
@@ -37,13 +51,68 @@ import javax.ws.rs.core.Response;
 public final class TokenService {
 
     /**
-     * A stubbed resource.
+     * Hibernate session to use.
+     */
+    private final Session session;
+
+    /**
+     * Client credentials.
+     */
+    private final Credentials credentials;
+
+    /**
+     * Service locator.
+     */
+    private final ServiceLocator locator;
+
+    /**
+     * Create a new token service.
      *
-     * @return 200 OK
+     * @param session     Injected hibernate session.
+     * @param credentials Injected, resolved client credentials.
+     * @param locator     Service locator, to find the appropriate request
+     *                    handler.
+     */
+    @Inject
+    public TokenService(final Session session,
+                        final Credentials credentials,
+                        final ServiceLocator locator) {
+        this.session = session;
+        this.credentials = credentials;
+        this.locator = locator;
+    }
+
+    /**
+     * Attempt to issue a token based on the requested grant type.
+     *
+     * @param uriInfo   The raw HTTP request.
+     * @param formData  The form post data.
+     * @param grantType The requested granttype.
+     * @return The processed response.
      */
     @POST
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response tokenRequest() {
-        return Response.ok().build();
+    public Response tokenRequest(
+            @Context final UriInfo uriInfo,
+            final MultivaluedMap<String, String> formData,
+            @FormParam("grant_type") @DefaultValue("")
+            final String grantType) {
+
+        // Resolve the client - validation is handled by the filters.
+        Client client = session.get(Client.class, credentials.getLogin());
+
+        // Get and validate the grant type.
+        IGrantTypeHandler handler = locator.getService(
+                IGrantTypeHandler.class, grantType);
+        if (handler == null) {
+            throw new InvalidGrantException();
+        }
+
+        // Build the token.
+        TokenResponseEntity e = handler.handle(client, formData);
+
+        // Return the token.
+        return Response.ok().entity(e).build();
     }
 }

--- a/src/main/java/net/krotscheck/api/oauth/resource/grant/ClientCredentialsGrantHandler.java
+++ b/src/main/java/net/krotscheck/api/oauth/resource/grant/ClientCredentialsGrantHandler.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.api.oauth.resource.grant;
+
+import net.krotscheck.api.oauth.exception.exception.Rfc6749Exception.InvalidGrantException;
+import net.krotscheck.api.oauth.exception.exception.Rfc6749Exception.UnauthorizedClientException;
+import net.krotscheck.api.oauth.resource.TokenResponseEntity;
+import net.krotscheck.api.oauth.util.ValidationUtil;
+import net.krotscheck.features.database.entity.ApplicationScope;
+import net.krotscheck.features.database.entity.Client;
+import net.krotscheck.features.database.entity.ClientType;
+import net.krotscheck.features.database.entity.OAuthToken;
+import net.krotscheck.features.database.entity.OAuthTokenType;
+import org.apache.commons.lang3.StringUtils;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.process.internal.RequestScoped;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+
+import java.util.SortedMap;
+import javax.inject.Inject;
+import javax.ws.rs.core.MultivaluedMap;
+
+/**
+ * This grant type handler takes care of the "client_credentials" grant_type
+ * OAuth flow. Its job is to provide a general-purpose access token to a
+ * privileged client, such as another API server that needs to validate tokens.
+ *
+ * @author Michael Krotscheck
+ */
+public final class ClientCredentialsGrantHandler implements IGrantTypeHandler {
+
+    /**
+     * Hibernate session, injected.
+     */
+    private final Session session;
+
+    /**
+     * Create a new instance of this grant handler.
+     *
+     * @param session Injected hibernate session.
+     */
+    @Inject
+    public ClientCredentialsGrantHandler(final Session session) {
+        this.session = session;
+    }
+
+    /**
+     * Apply the client credentials flow to this request.
+     *
+     * @param client   The Client to use.
+     * @param formData Raw form data for the request.
+     * @return A response indicating the result of the request.
+     */
+    @Override
+    public TokenResponseEntity handle(final Client client,
+                                      final MultivaluedMap<String, String>
+                                              formData) {
+
+        // Make sure the client is the correct type.
+        if (!client.getType().equals(ClientType.ClientCredentials)) {
+            throw new InvalidGrantException();
+        }
+
+        // Ensure that the client is authorized. This is actually handled in
+        // the ClientAuthorizationFilter; here we check the edge case of a
+        // ClientCredentials type with no set client_secret.
+        if (StringUtils.isEmpty(client.getClientSecret())) {
+            throw new UnauthorizedClientException();
+        }
+
+        // Make sure all requested scopes are in the map.
+        SortedMap<String, ApplicationScope> requestedScopes =
+                ValidationUtil.validateScope(formData.getFirst("scope"),
+                        client.getApplication().getScopes());
+
+        // Ensure that we retrieve a state, if it exists.
+        String state = formData.getFirst("state");
+
+        // Go ahead and create the token.
+        OAuthToken token = new OAuthToken();
+        token.setClient(client);
+        token.setTokenType(OAuthTokenType.Bearer);
+        token.setExpiresIn(client.getAccessTokenExpireIn());
+        token.setScopes(requestedScopes);
+
+        Transaction t = session.beginTransaction();
+        session.save(token);
+        t.commit();
+
+        return TokenResponseEntity.factory(token, state);
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bind(ClientCredentialsGrantHandler.class)
+                    .to(IGrantTypeHandler.class)
+                    .named("client_credentials")
+                    .in(RequestScoped.class);
+        }
+    }
+}

--- a/src/main/java/net/krotscheck/api/oauth/resource/grant/IGrantTypeHandler.java
+++ b/src/main/java/net/krotscheck/api/oauth/resource/grant/IGrantTypeHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.api.oauth.resource.grant;
+
+import net.krotscheck.api.oauth.resource.TokenResponseEntity;
+import net.krotscheck.features.database.entity.Client;
+
+import javax.ws.rs.core.MultivaluedMap;
+
+/**
+ * This interface describes a processing entity which encapsulates some logic
+ * for a specific token grant_type.
+ *
+ * @author Michael Krotscheck
+ */
+public interface IGrantTypeHandler {
+
+    /**
+     * Handle a specific grant type request.
+     *
+     * @param client   The client.
+     * @param formData Additional form data.
+     * @return A token response entity with the new token.
+     */
+    TokenResponseEntity handle(Client client,
+                               MultivaluedMap<String, String> formData);
+}

--- a/src/main/java/net/krotscheck/api/oauth/resource/grant/package-info.java
+++ b/src/main/java/net/krotscheck/api/oauth/resource/grant/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Handlers for each type of grant_type request.
+ */
+package net.krotscheck.api.oauth.resource.grant;

--- a/src/test/java/net/krotscheck/api/oauth/resource/grant/ClientCredentialsGrantHandlerTest.java
+++ b/src/test/java/net/krotscheck/api/oauth/resource/grant/ClientCredentialsGrantHandlerTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.api.oauth.resource.grant;
+
+import net.krotscheck.api.oauth.exception.exception.Rfc6749Exception.InvalidGrantException;
+import net.krotscheck.api.oauth.exception.exception.Rfc6749Exception.InvalidScopeException;
+import net.krotscheck.api.oauth.exception.exception.Rfc6749Exception.UnauthorizedClientException;
+import net.krotscheck.api.oauth.resource.TokenResponseEntity;
+import net.krotscheck.features.database.entity.Client;
+import net.krotscheck.features.database.entity.ClientConfig;
+import net.krotscheck.features.database.entity.ClientType;
+import net.krotscheck.features.database.entity.OAuthTokenType;
+import net.krotscheck.test.DatabaseTest;
+import net.krotscheck.test.EnvironmentBuilder;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+/**
+ * These tests ensure coverage on the Client Credentials token grant type
+ * handler, covered in RFC6749.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.4">https://tools.ietf.org/html/rfc6749#section-4.4</a>
+ */
+public final class ClientCredentialsGrantHandlerTest extends DatabaseTest {
+
+    /**
+     * The harness under test.
+     */
+    private ClientCredentialsGrantHandler handler;
+
+    /**
+     * A simple, scoped context.
+     */
+    private EnvironmentBuilder context;
+
+    /**
+     * A non-client-credentials context.
+     */
+    private EnvironmentBuilder implicitContext;
+
+    /**
+     * A context with no configured scopes.
+     */
+    private EnvironmentBuilder noScopeContext;
+
+    /**
+     * A no-secret Context.
+     */
+    private EnvironmentBuilder noSecretContext;
+
+    /**
+     * Setup the test.
+     */
+    @Before
+    public void initializeEnvironment() {
+        handler = new ClientCredentialsGrantHandler(getSession());
+    }
+
+    /**
+     * Set up the test harness data.
+     */
+    @Before
+    public void createTestData() {
+        context = setupEnvironment()
+                .client(ClientType.ClientCredentials, true)
+                .scope("debug");
+        noScopeContext = setupEnvironment()
+                .client(ClientType.ClientCredentials, true);
+        implicitContext = setupEnvironment()
+                .client(ClientType.Implicit, true)
+                .scope("debug");
+        noSecretContext = setupEnvironment()
+                .client(ClientType.ClientCredentials)
+                .scope("debug");
+
+        // The environment builder detaches its data, this reconnects it.
+        getSession().refresh(context.getClient());
+    }
+
+    /**
+     * Assert that a valid request works.
+     */
+    @Test
+    public void testValidRequest() {
+        MultivaluedMap<String, String> testData = new MultivaluedHashMap<>();
+        testData.putSingle("client_id",
+                context.getClient().getId().toString());
+        testData.putSingle("client_secret",
+                context.getClient().getClientSecret());
+        testData.putSingle("scope", "debug");
+        testData.putSingle("grant_type", "client_credentials");
+
+        TokenResponseEntity token = handler.handle(context.getClient(),
+                testData);
+        Assert.assertEquals(OAuthTokenType.Bearer, token.getTokenType());
+        Assert.assertEquals((long) ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
+                (long) token.getExpiresIn());
+        Assert.assertNull(token.getRefreshToken());
+        Assert.assertEquals("debug", token.getScope());
+        Assert.assertNotNull(token.getAccessToken());
+    }
+
+    /**
+     * Assert that requesting client_credentials against a
+     * non-client_credentials client fails.
+     */
+    @Test(expected = InvalidGrantException.class)
+    public void testInvalidClientType() {
+        MultivaluedMap<String, String> testData = new MultivaluedHashMap<>();
+        testData.putSingle("client_id",
+                implicitContext.getClient().getId().toString());
+        testData.putSingle("client_secret",
+                implicitContext.getClient().getClientSecret());
+        testData.putSingle("scope", "debug");
+        testData.putSingle("grant_type", "client_credentials");
+
+        handler.handle(implicitContext.getClient(), testData);
+    }
+
+    /**
+     * Assert that requesting client_credentials with a client that has no
+     * secret fails.
+     */
+    @Test(expected = UnauthorizedClientException.class)
+    public void testNoClientSecret() {
+        MultivaluedMap<String, String> testData = new MultivaluedHashMap<>();
+        testData.putSingle("client_id",
+                noSecretContext.getClient().getId().toString());
+        testData.putSingle("scope", "debug");
+        testData.putSingle("grant_type", "client_credentials");
+
+        handler.handle(noSecretContext.getClient(), testData);
+    }
+
+    /**
+     * Assert that requesting a scope that is not permitted fails.
+     */
+    @Test(expected = InvalidScopeException.class)
+    public void testInvalidScope() {
+        MultivaluedMap<String, String> testData = new MultivaluedHashMap<>();
+        testData.putSingle("client_id",
+                context.getClient().getId().toString());
+        testData.putSingle("client_secret",
+                context.getClient().getClientSecret());
+        testData.putSingle("scope", "debug invalid");
+        testData.putSingle("grant_type", "client_credentials");
+
+        handler.handle(context.getClient(), testData);
+    }
+
+    /**
+     * Assert that we can still make requests against an application with no
+     * scopes.
+     */
+    @Test
+    public void testNoScope() {
+        Client c = noScopeContext.getClient();
+        MultivaluedMap<String, String> testData = new MultivaluedHashMap<>();
+        testData.putSingle("client_id", c.getId().toString());
+        testData.putSingle("client_secret", c.getClientSecret());
+        testData.putSingle("scope", "");
+        testData.putSingle("grant_type", "client_credentials");
+
+        TokenResponseEntity token = handler.handle(c, testData);
+        Assert.assertEquals(OAuthTokenType.Bearer, token.getTokenType());
+        Assert.assertEquals((long) ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
+                (long) token.getExpiresIn());
+        Assert.assertNull(token.getRefreshToken());
+        Assert.assertNull(token.getScope());
+        Assert.assertNotNull(token.getAccessToken());
+    }
+}

--- a/src/test/java/net/krotscheck/api/oauth/resource/grant/package-info.java
+++ b/src/test/java/net/krotscheck/api/oauth/resource/grant/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for our /token endpoint grant handlers.
+ */
+package net.krotscheck.api.oauth.resource.grant;

--- a/src/test/java/net/krotscheck/api/oauth/rfc6749/Section440ClientCredentialsTest.java
+++ b/src/test/java/net/krotscheck/api/oauth/rfc6749/Section440ClientCredentialsTest.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.api.oauth.rfc6749;
+
+import net.krotscheck.api.oauth.resource.TokenResponseEntity;
+import net.krotscheck.features.database.entity.Client;
+import net.krotscheck.features.database.entity.ClientConfig;
+import net.krotscheck.features.database.entity.ClientType;
+import net.krotscheck.features.database.entity.OAuthTokenType;
+import net.krotscheck.features.exception.ErrorResponseBuilder.ErrorResponse;
+import net.krotscheck.test.EnvironmentBuilder;
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * These tests run through the Client Credentials Flow. In this context, the
+ * client authenticates only via their clientID and client secret.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.4">https://tools.ietf.org/html/rfc6749#section-4.4</a>
+ */
+public final class Section440ClientCredentialsTest
+        extends AbstractRFC6749Test {
+
+    /**
+     * Generic context.
+     */
+    private EnvironmentBuilder context;
+
+    /**
+     * The test context for an authenticated application.
+     */
+    private EnvironmentBuilder authContext;
+
+    /**
+     * The auth header string for each test.
+     */
+    private String authHeader;
+
+    /**
+     * Bootstrap the application.
+     */
+    @Before
+    public void bootstrap() {
+        context = setupEnvironment()
+                .scope("debug")
+                .client(ClientType.ClientCredentials, false);
+        authContext = setupEnvironment()
+                .scope("debug")
+                .client(ClientType.ClientCredentials, true);
+        authHeader = buildAuthorizationHeader(
+                authContext.getClient().getId(),
+                authContext.getClient().getClientSecret());
+    }
+
+    /**
+     * Assert that a simple token request works.
+     */
+    @Test
+    public void testTokenSimpleRequest() {
+        Client c = authContext.getClient();
+
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", c.getId().toString());
+        f.param("client_secret", c.getClientSecret());
+        f.param("grant_type", "client_credentials");
+
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token").request().post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_OK, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
+        assertNotNull(entity.getAccessToken());
+        assertNull(entity.getRefreshToken());
+        assertEquals((long) ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
+                (long) entity.getExpiresIn());
+        assertNull(entity.getScope());
+        assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
+    }
+
+    /**
+     * Assert that a bad password errors.
+     */
+    @Test
+    public void testBadPassword() {
+        Client c = authContext.getClient();
+
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", c.getId().toString());
+        f.param("client_secret", "invalid_secret");
+        f.param("grant_type", "client_credentials");
+
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token").request().post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_UNAUTHORIZED, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("access_denied", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+
+    /**
+     * Assert that missing a client id errors.
+     */
+    @Test
+    public void testTokenNoClientId() {
+        // Build the entity.
+        Form f = new Form();
+        f.param("grant_type", "client_credentials");
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+
+        // Make the request
+        Response r = target("/token").request().post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_BAD_REQUEST, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("invalid_client", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+
+    /**
+     * Assert that missing a grant type errors.
+     */
+    @Test
+    public void testTokenNoGrant() {
+        Client c = authContext.getClient();
+
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", c.getId().toString());
+        f.param("client_secret", c.getClientSecret());
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token").request().post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_BAD_REQUEST, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("invalid_grant", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+
+    /**
+     * Assert that we can authenticate via the auth header.
+     */
+    @Test
+    public void testTokenAuthHeaderValid() {
+        Client c = authContext.getClient();
+
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", c.getId().toString());
+        f.param("grant_type", "client_credentials");
+        f.param("scope", "debug");
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token")
+                .request()
+                .header("Authorization", authHeader)
+                .post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_OK, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
+        assertNotNull(entity.getAccessToken());
+        assertNull(entity.getRefreshToken());
+        assertEquals((long) ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
+                (long) entity.getExpiresIn());
+        assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
+        assertEquals("debug", entity.getScope());
+    }
+
+    /**
+     * Test that a user that provides a mismatched client_id in the request
+     * body and the Authorization header fails.
+     */
+    @Test
+    public void testTokenAuthHeaderMismatchClientId() {
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", context.getClient().getId().toString());
+        f.param("grant_type", "client_credentials");
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token")
+                .request()
+                .header("Authorization", authHeader)
+                .post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_BAD_REQUEST, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("invalid_client", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+
+    /**
+     * Test that a user may not identify themselves solely via the
+     * Authorization header.
+     */
+    @Test
+    public void testTokenAuthHeaderValidNoExplicitClientId() {
+        // Build the entity.
+        Form f = new Form();
+        f.param("grant_type", "client_credentials");
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token")
+                .request()
+                .header("Authorization", authHeader)
+                .post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_BAD_REQUEST, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("invalid_client", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+
+    /**
+     * Test that authorization via the header with a bad client_credentials
+     * fails.
+     */
+    @Test
+    public void testTokenAuthHeaderInvalid() {
+        Client c = authContext.getClient();
+        String authHeader = buildAuthorizationHeader(c.getId(),
+                "badsecret");
+
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", c.getId().toString());
+        f.param("grant_type", "client_credentials");
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token")
+                .request()
+                .header("Authorization", authHeader)
+                .post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_UNAUTHORIZED, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("access_denied", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+
+    /**
+     * Assert that only one authentication method may be used.
+     */
+    @Test
+    public void testTokenAuthBothMethods() {
+        Client c = authContext.getClient();
+
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", c.getId().toString());
+        f.param("client_secret", c.getClientSecret());
+        f.param("grant_type", "client_credentials");
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token")
+                .request()
+                .header("Authorization", authHeader)
+                .post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_BAD_REQUEST, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("invalid_client", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+
+    /**
+     * Assert that an invalid grant type errors.
+     */
+    @Test
+    public void testTokenInvalidGrantTypePassword() {
+        Client c = authContext.getClient();
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", c.getId().toString());
+        f.param("client_secret", c.getClientSecret());
+        f.param("grant_type", "password");
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token").request().post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_BAD_REQUEST, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("invalid_grant", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+
+    /**
+     * Assert that an invalid grant type errors.
+     */
+    @Test
+    public void testTokenInvalidGrantTypeRefreshToken() {
+        Client c = authContext.getClient();
+
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", c.getId().toString());
+        f.param("client_secret", c.getClientSecret());
+        f.param("grant_type", "refresh_token");
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token").request().post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_BAD_REQUEST, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("invalid_grant", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+
+    /**
+     * Assert that an unknown grant type errors.
+     */
+    @Test
+    public void testTokenUnknownGrantType() {
+        Client c = authContext.getClient();
+
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", c.getId().toString());
+        f.param("client_secret", c.getClientSecret());
+        f.param("grant_type", "unknown_grant_type");
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token").request().post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_BAD_REQUEST, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("invalid_grant", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+}


### PR DESCRIPTION
This patch sets up handling of different grant request types, by checking
the injection context for appropriately named Grant handlers. It also
creates a handler for the 'client_credentials' OAuth2 flow documented in
section 4.4.0 of the OAuth2 Specification.