### PR TITLE
Created Grant Handler for Owner Credentials.

### DIFF
--- a/src/main/java/net/krotscheck/api/oauth/OAuthAPI.java
+++ b/src/main/java/net/krotscheck/api/oauth/OAuthAPI.java
@@ -17,12 +17,14 @@
 
 package net.krotscheck.api.oauth;
 
+import net.krotscheck.api.oauth.authenticator.PasswordAuthenticator;
 import net.krotscheck.api.oauth.factory.CredentialsFactory;
 import net.krotscheck.api.oauth.filter.ClientAuthorizationFilter;
 import net.krotscheck.api.oauth.resource.AuthorizationService;
 import net.krotscheck.api.oauth.resource.TokenService;
 import net.krotscheck.api.oauth.resource.grant.AuthorizationCodeGrantHandler;
 import net.krotscheck.api.oauth.resource.grant.ClientCredentialsGrantHandler;
+import net.krotscheck.api.oauth.resource.grant.OwnerCredentialsGrantHandler;
 import net.krotscheck.api.oauth.resource.grant.RefreshTokenGrantHandler;
 import net.krotscheck.features.config.ConfigurationFeature;
 import net.krotscheck.features.database.DatabaseFeature;
@@ -59,10 +61,14 @@ public class OAuthAPI extends ResourceConfig {
         // Service filters
         register(new ClientAuthorizationFilter.Binder());
 
+        // Authenticators
+        register(new PasswordAuthenticator.Binder());
+
         // ResponseType and GrantType handlers
         register(new ClientCredentialsGrantHandler.Binder());
         register(new RefreshTokenGrantHandler.Binder());
         register(new AuthorizationCodeGrantHandler.Binder());
+        register(new OwnerCredentialsGrantHandler.Binder());
 
         // Resource services
         register(TokenService.class);

--- a/src/main/java/net/krotscheck/api/oauth/authenticator/PasswordAuthenticator.java
+++ b/src/main/java/net/krotscheck/api/oauth/authenticator/PasswordAuthenticator.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.api.oauth.authenticator;
+
+import net.krotscheck.api.oauth.exception.exception.Rfc6749Exception.InvalidRequestException;
+import net.krotscheck.features.database.entity.Authenticator;
+import net.krotscheck.features.database.entity.UserIdentity;
+import net.krotscheck.features.security.PasswordUtil;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.process.internal.RequestScoped;
+import org.hibernate.Criteria;
+import org.hibernate.Session;
+import org.hibernate.criterion.Restrictions;
+
+import java.net.URI;
+import java.util.List;
+import javax.inject.Inject;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+/**
+ * The PasswordAuthenticator is a specific implementation of the
+ * IAuthenticator interface to support the Owner Credentials flow. It is
+ * injected into the scope without a name, so that it cannot be chosen using
+ * the standard multiauth feature.
+ *
+ * @author Michael Krotscheck
+ */
+public final class PasswordAuthenticator
+        extends AbstractAuthenticator
+        implements IAuthenticator {
+
+    /**
+     * Hibernate session, for data access.
+     */
+    private final Session session;
+
+    /**
+     * Create a new password authenticator.
+     *
+     * @param session An injected hibernate session.
+     */
+    @Inject
+    public PasswordAuthenticator(final Session session) {
+        this.session = session;
+    }
+
+    /**
+     * Do nothing, this authenticator does not delegate.
+     *
+     * @param configuration The authenticator configuration.
+     * @param callback      The redirect, on this server, where the response
+     *                      should go.
+     * @return An HTTP response, redirecting the client to the next step.
+     */
+    @Override
+    public Response delegate(final Authenticator configuration,
+                             final URI callback) {
+        return null;
+    }
+
+    /**
+     * Resolve and/or create a user identity for a specific client, given the
+     * returned URI.
+     *
+     * @param configuration The authenticator configuration.
+     * @param parameters    Parameters for the authenticator, retrieved from
+     *                      an appropriate source.
+     * @return A user identity.
+     */
+    @Override
+    public UserIdentity authenticate(final Authenticator configuration,
+                                     final MultivaluedMap<String, String>
+                                             parameters) {
+        // Validate the input
+        if (configuration == null || parameters == null) {
+            throw new InvalidRequestException();
+        }
+
+        // Extract the login and password.
+        String login = getOne(parameters, "username");
+        String password = getOne(parameters, "password");
+
+        // Try to find this user.
+        Criteria c = session.createCriteria(UserIdentity.class);
+        c.add(Restrictions.eq("remoteId", login));
+        c.add(Restrictions.eq("authenticator", configuration));
+        c.setFirstResult(0);
+        c.setMaxResults(1);
+        List<UserIdentity> results = c.list();
+        if (c.list().size() == 0) {
+            return null;
+        }
+
+        // Is the password correct?
+        UserIdentity identity = results.get(0);
+        Boolean isValid = PasswordUtil.isValid(password, identity.getSalt(),
+                identity.getPassword());
+        if (!isValid) {
+            return null;
+        }
+        return identity;
+    }
+
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bind(PasswordAuthenticator.class)
+                    .to(PasswordAuthenticator.class)
+                    .in(RequestScoped.class);
+        }
+    }
+}

--- a/src/main/java/net/krotscheck/api/oauth/resource/grant/OwnerCredentialsGrantHandler.java
+++ b/src/main/java/net/krotscheck/api/oauth/resource/grant/OwnerCredentialsGrantHandler.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.api.oauth.resource.grant;
+
+import net.krotscheck.api.oauth.authenticator.IAuthenticator;
+import net.krotscheck.api.oauth.authenticator.PasswordAuthenticator;
+import net.krotscheck.api.oauth.exception.exception.Rfc6749Exception.InvalidGrantException;
+import net.krotscheck.api.oauth.resource.TokenResponseEntity;
+import net.krotscheck.api.oauth.util.ValidationUtil;
+import net.krotscheck.features.database.entity.ApplicationScope;
+import net.krotscheck.features.database.entity.Authenticator;
+import net.krotscheck.features.database.entity.Client;
+import net.krotscheck.features.database.entity.ClientType;
+import net.krotscheck.features.database.entity.OAuthToken;
+import net.krotscheck.features.database.entity.OAuthTokenType;
+import net.krotscheck.features.database.entity.UserIdentity;
+import net.krotscheck.features.exception.exception.HttpStatusException;
+import org.apache.http.HttpStatus;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.process.internal.RequestScoped;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+
+import java.util.SortedMap;
+import javax.inject.Inject;
+import javax.ws.rs.core.MultivaluedMap;
+
+/**
+ * This grant type handler takes care of the "password" grant_type
+ * OAuth flow. For situations in which a user/password is preferred, we offer
+ * a simplified login mechanism, though we do not encourage its use.
+ *
+ * @author Michael Krotscheck
+ */
+public final class OwnerCredentialsGrantHandler implements IGrantTypeHandler {
+
+    /**
+     * Hibernate session, injected.
+     */
+    private final Session session;
+
+    /**
+     * Service locator, injected.
+     */
+    private final ServiceLocator locator;
+
+    /**
+     * Create a new instance of this grant handler.
+     *
+     * @param session Injected hibernate session.
+     * @param locator The service locator.
+     */
+    @Inject
+    public OwnerCredentialsGrantHandler(final Session session,
+                                        final ServiceLocator locator) {
+        this.session = session;
+        this.locator = locator;
+    }
+
+    /**
+     * Apply the client credentials flow to this request.
+     *
+     * @param client   The Client to use.
+     * @param formData Raw form data for the request.
+     * @return A response indicating the result of the request.
+     */
+    @Override
+    public TokenResponseEntity handle(final Client client,
+                                      final MultivaluedMap<String, String>
+                                              formData) {
+        // Make sure the client is the correct type.
+        if (!client.getType().equals(ClientType.OwnerCredentials)) {
+            throw new InvalidGrantException();
+        }
+
+        // Get the authenticator impl.
+        IAuthenticator authenticator =
+                locator.getService(PasswordAuthenticator.class);
+
+        // Pull the password authenticator configuration.
+        Authenticator authConfig = ValidationUtil
+                .validateAuthenticator("password", client.getAuthenticators());
+
+        // Try to resolve a user identity.
+        UserIdentity identity = authenticator
+                .authenticate(authConfig, formData);
+        if (identity == null) {
+            throw new HttpStatusException(HttpStatus.SC_UNAUTHORIZED);
+        }
+
+        // Make sure all requested scopes are in the map.
+        SortedMap<String, ApplicationScope> requestedScopes =
+                ValidationUtil.validateScope(formData.getFirst("scope"),
+                        client.getApplication().getScopes());
+
+        // Ensure that we retrieve a state, if it exists.
+        String state = formData.getFirst("state");
+
+        // Go ahead and create the token.
+        OAuthToken token = new OAuthToken();
+        token.setClient(client);
+        token.setTokenType(OAuthTokenType.Bearer);
+        token.setExpiresIn(client.getAccessTokenExpireIn());
+        token.setScopes(requestedScopes);
+        token.setIdentity(identity);
+
+        OAuthToken refreshToken = new OAuthToken();
+        refreshToken.setClient(client);
+        refreshToken.setTokenType(OAuthTokenType.Refresh);
+        refreshToken.setExpiresIn(client.getRefreshTokenExpireIn());
+        refreshToken.setScopes(token.getScopes());
+        refreshToken.setAuthToken(token);
+
+        Transaction t = session.beginTransaction();
+        session.save(token);
+        session.save(refreshToken);
+        t.commit();
+
+        return TokenResponseEntity.factory(token, refreshToken, state);
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bind(OwnerCredentialsGrantHandler.class)
+                    .to(IGrantTypeHandler.class)
+                    .named("password")
+                    .in(RequestScoped.class);
+        }
+    }
+}

--- a/src/test/java/net/krotscheck/api/oauth/authenticator/PasswordAuthenticatorTest.java
+++ b/src/test/java/net/krotscheck/api/oauth/authenticator/PasswordAuthenticatorTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.api.oauth.authenticator;
+
+import net.krotscheck.api.oauth.exception.exception.Rfc6749Exception.InvalidRequestException;
+import net.krotscheck.features.database.entity.Authenticator;
+import net.krotscheck.features.database.entity.ClientType;
+import net.krotscheck.features.database.entity.UserIdentity;
+import net.krotscheck.test.DatabaseTest;
+import net.krotscheck.test.EnvironmentBuilder;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+
+/**
+ * Unit tests for the password authenticator.
+ *
+ * @author Michael Krotscheck
+ */
+public final class PasswordAuthenticatorTest extends DatabaseTest {
+
+    /**
+     * Basic testing context.
+     */
+    private EnvironmentBuilder context;
+
+    /**
+     * Setup our testing data.
+     */
+    @Before
+    public void setup() {
+        context = setupEnvironment()
+                .client(ClientType.OwnerCredentials)
+                .authenticator("password")
+                .user()
+                .login("login", "password");
+    }
+
+    /**
+     * Assert that the test delegate does nothing.
+     */
+    @Test
+    public void testDelegate() {
+        IAuthenticator a = new PasswordAuthenticator(getSession());
+
+        Authenticator config = new Authenticator();
+        URI callback = UriBuilder.fromPath("http://example.com").build();
+
+        Response r = a.delegate(config, callback);
+        Assert.assertNull(r);
+    }
+
+    /**
+     * Test that a valid authentication works.
+     */
+    @Test
+    public void testAuthenticateValid() {
+        IAuthenticator a = new PasswordAuthenticator(getSession());
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.add("username", "login");
+        params.add("password", "password");
+        UserIdentity i = a.authenticate(context.getAuthenticator(), params);
+        Assert.assertEquals(context.getUserIdentity(), i);
+    }
+
+    /**
+     * Assert that trying to authenticate with a null input fails.
+     */
+    @Test(expected = InvalidRequestException.class)
+    public void testAuthenticateNullConfig() {
+        IAuthenticator a = new PasswordAuthenticator(getSession());
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        a.authenticate(null, params);
+    }
+
+    /**
+     * Assert that trying to authenticate with a null input fails.
+     */
+    @Test(expected = InvalidRequestException.class)
+    public void testAuthenticateNullParams() {
+        IAuthenticator a = new PasswordAuthenticator(getSession());
+        Authenticator config = new Authenticator();
+        a.authenticate(config, null);
+    }
+
+    /**
+     * Assert that trying to authenticate with no matching identity fails.
+     */
+    @Test
+    public void testAuthenticateNoIdentity() {
+        IAuthenticator a = new PasswordAuthenticator(getSession());
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.add("username", "wrongIdentity");
+        params.add("password", "password");
+        UserIdentity i = a.authenticate(context.getAuthenticator(), params);
+        Assert.assertNull(i);
+    }
+
+    /**
+     * Assert that trying to authenticate with a wrong password fails.
+     */
+    @Test
+    public void testAuthenticateWrongPassword() {
+        IAuthenticator a = new PasswordAuthenticator(getSession());
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.add("username", "login");
+        params.add("password", "wrongpassword");
+        UserIdentity i = a.authenticate(context.getAuthenticator(), params);
+        Assert.assertNull(i);
+    }
+}

--- a/src/test/java/net/krotscheck/api/oauth/rfc6749/Section430OwnerPasswordTest.java
+++ b/src/test/java/net/krotscheck/api/oauth/rfc6749/Section430OwnerPasswordTest.java
@@ -1,0 +1,465 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.api.oauth.rfc6749;
+
+import net.krotscheck.api.oauth.resource.TokenResponseEntity;
+import net.krotscheck.features.database.entity.Client;
+import net.krotscheck.features.database.entity.ClientConfig;
+import net.krotscheck.features.database.entity.ClientType;
+import net.krotscheck.features.database.entity.OAuthTokenType;
+import net.krotscheck.features.exception.ErrorResponseBuilder.ErrorResponse;
+import net.krotscheck.test.EnvironmentBuilder;
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * These tests run through the Owner Password Flow. In this context, the
+ * owner must be manually assigned a userid or password.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.3">https://tools.ietf.org/html/rfc6749#section-4.3</a>
+ */
+public final class Section430OwnerPasswordTest
+        extends AbstractRFC6749Test {
+
+    /**
+     * User name used for valid requests.
+     */
+    private String username = "valid_user";
+
+    /**
+     * The password used for valid requests.
+     */
+    private String password = "valid_password";
+
+    /**
+     * The environment builder for the regular client.
+     */
+    private EnvironmentBuilder builder;
+
+    /**
+     * The environment builder for the authentication client.
+     */
+    private EnvironmentBuilder authBuilder;
+
+    /**
+     * The auth header string for each test.
+     */
+    private String authHeader;
+
+    /**
+     * Bootstrap the application.
+     */
+    @Before
+    public void bootstrap() {
+        builder = setupEnvironment()
+                .scope("debug")
+                .client(ClientType.OwnerCredentials)
+                .authenticator("password")
+                .user()
+                .login(username, password);
+        authBuilder = setupEnvironment()
+                .scope("debug")
+                .client(ClientType.OwnerCredentials, true)
+                .authenticator("password")
+                .user()
+                .login(username, password);
+        authHeader = buildAuthorizationHeader(
+                authBuilder.getClient().getId(),
+                authBuilder.getClient().getClientSecret());
+    }
+
+    /**
+     * Assert that a simple token request works.
+     */
+    @Test
+    public void testTokenSimpleRequest() {
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", builder.getClient().getId().toString());
+        f.param("grant_type", "password");
+        f.param("username", username);
+        f.param("password", password);
+
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token").request().post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_OK, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
+        assertNotNull(entity.getAccessToken());
+        assertNotNull(entity.getRefreshToken());
+        assertEquals((int) ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
+                entity.getExpiresIn().intValue());
+        assertNull(entity.getScope());
+        assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
+    }
+
+    /**
+     * Assert that using the wrong password fails.
+     */
+    @Test
+    public void testTokenBadAuth() {
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", builder.getClient().getId().toString());
+        f.param("grant_type", "password");
+        f.param("username", username);
+        f.param("password", "wrong_password");
+
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token").request().post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_UNAUTHORIZED, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("unauthorized", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+
+    /**
+     * Assert that missing a client id errors.
+     */
+    @Test
+    public void testTokenNoClientId() {
+        // Build the entity.
+        Form f = new Form();
+        f.param("grant_type", "password");
+        f.param("username", username);
+        f.param("password", password);
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+
+        // Make the request
+        Response r = target("/token").request().post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_BAD_REQUEST, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("invalid_client", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+
+    /**
+     * Assert that missing a grant type errors.
+     */
+    @Test
+    public void testTokenNoGrant() {
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", builder.getClient().getId().toString());
+        f.param("username", username);
+        f.param("password", password);
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token").request().post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_BAD_REQUEST, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("invalid_grant", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+
+    /**
+     * Test that, if the client provides a token password, that
+     * authentication using that password via the Authorization header works.
+     */
+    @Test
+    public void testTokenAuthHeaderValid() {
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", authBuilder.getClient().getId().toString());
+        f.param("grant_type", "password");
+        f.param("scope", "debug");
+        f.param("username", username);
+        f.param("password", password);
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token")
+                .request()
+                .header("Authorization", authHeader)
+                .post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_OK, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
+        assertNotNull(entity.getAccessToken());
+        assertNotNull(entity.getRefreshToken());
+        assertEquals((int) ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
+                entity.getExpiresIn().intValue());
+        assertEquals("debug", entity.getScope());
+        assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
+    }
+
+    /**
+     * Test that a user that provides a mismatched client_id in the request
+     * body and the Authorization header fails.
+     */
+    @Test
+    public void testTokenAuthHeaderMismatchClientId() {
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", builder.getClient().getId().toString());
+        f.param("grant_type", "password");
+        f.param("username", username);
+        f.param("password", password);
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token")
+                .request()
+                .header("Authorization", authHeader)
+                .post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_BAD_REQUEST, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("invalid_client", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+
+    /**
+     * Test that a user may not identify themselves solely via the
+     * Authorization header.
+     */
+    @Test
+    public void testTokenAuthHeaderValidNoExplicitClientId() {
+        // Build the entity.
+        Form f = new Form();
+        f.param("grant_type", "password");
+        f.param("username", username);
+        f.param("password", password);
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token")
+                .request()
+                .header("Authorization", authHeader)
+                .post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_BAD_REQUEST, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("invalid_client", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+
+    /**
+     * Test that authorization via the header with a bad password fails.
+     */
+    @Test
+    public void testTokenAuthHeaderInvalid() {
+        String badHeader = buildAuthorizationHeader(
+                authBuilder.getClient().getId(),
+                "badsecret");
+
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", authBuilder.getClient().getId().toString());
+        f.param("grant_type", "password");
+        f.param("username", username);
+        f.param("password", password);
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token")
+                .request()
+                .header("Authorization", badHeader)
+                .post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_UNAUTHORIZED, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("access_denied", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+
+    /**
+     * Test that a client may also authenticate by putting the client_secret
+     * in the post body.
+     */
+    @Test
+    public void testTokenAuthSecretInBody() {
+        Client c = authBuilder.getClient();
+
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", c.getId().toString());
+        f.param("client_secret", c.getClientSecret());
+        f.param("grant_type", "password");
+        f.param("scope", "debug");
+        f.param("username", username);
+        f.param("password", password);
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token").request()
+                .post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_OK, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
+        assertNotNull(entity.getAccessToken());
+        assertNotNull(entity.getRefreshToken());
+        assertEquals((int) ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
+                entity.getExpiresIn().intValue());
+        assertEquals("debug", entity.getScope());
+        assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
+    }
+
+    /**
+     * Assert that only one authentication method may be used.
+     */
+    @Test
+    public void testTokenAuthBothMethods() {
+        Client c = authBuilder.getClient();
+
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", c.getId().toString());
+        f.param("client_secret", c.getClientSecret());
+        f.param("grant_type", "password");
+        f.param("username", username);
+        f.param("password", password);
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token")
+                .request()
+                .header("Authorization", authHeader)
+                .post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_BAD_REQUEST, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("invalid_client", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+
+    /**
+     * Assert that an invalid grant type errors.
+     */
+    @Test
+    public void testTokenInvalidGrantTypeRefreshToken() {
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", builder.getClient().getId().toString());
+        f.param("grant_type", "refresh_token");
+        f.param("username", username);
+        f.param("password", password);
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token").request().post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_BAD_REQUEST, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("invalid_grant", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+
+    /**
+     * Assert that an invalid grant type errors.
+     */
+    @Test
+    public void testTokenInvalidGrantTypeClientCredentials() {
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", builder.getClient().getId().toString());
+        f.param("grant_type", "client_credentials");
+        f.param("username", username);
+        f.param("password", password);
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token").request().post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_BAD_REQUEST, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("invalid_grant", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+
+    /**
+     * Assert that an unknown grant type errors.
+     */
+    @Test
+    public void testTokenUnknownGrantType() {
+        // Build the entity.
+        Form f = new Form();
+        f.param("client_id", builder.getClient().getId().toString());
+        f.param("grant_type", "unknown_grant_type");
+        f.param("username", username);
+        f.param("password", password);
+        Entity postEntity = Entity.entity(f,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        Response r = target("/token").request().post(postEntity);
+
+        // Assert various response-specific parameters.
+        assertEquals(HttpStatus.SC_BAD_REQUEST, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        // Validate the query parameters received.
+        ErrorResponse entity = r.readEntity(ErrorResponse.class);
+        assertEquals("invalid_grant", entity.getError());
+        assertNotNull(entity.getErrorDescription());
+    }
+}


### PR DESCRIPTION
This patch handles token requests for the 'password' grant_type. It
includes a 'secret' authenticator that checks passwords and salts
against the User Identity table.