### PR TITLE
This patch removes, or resolves, extraneous build log lines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
     <hibernate.version>5.0.6.Final</hibernate.version>
     <hibernate-search.version>5.5.1.Final</hibernate-search.version>
     <jersey2-toolkit.version>2.1.1</jersey2-toolkit.version>
+    <slf4j.version>1.7.13</slf4j.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -302,6 +303,8 @@
             </dependency>
           </dependencies>
           <configuration>
+            <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+
             <systemProperties>
               <property>
                 <name>test.db.jdbc</name>
@@ -536,7 +539,12 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.13</version>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -656,7 +664,7 @@
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-search</artifactId>
+      <artifactId>hibernate-search-orm</artifactId>
       <version>${hibernate-search.version}</version>
     </dependency>
     <dependency>

--- a/src/main/java/net/krotscheck/features/database/deserializer/AbstractEntityReferenceDeserializer.java
+++ b/src/main/java/net/krotscheck/features/database/deserializer/AbstractEntityReferenceDeserializer.java
@@ -56,6 +56,7 @@ public abstract class AbstractEntityReferenceDeserializer
      * @throws IOException Thrown when parsing fails.
      */
     @Override
+    @SuppressWarnings("unchecked")
     public final T deserialize(final JsonParser parser,
                                final DeserializationContext context)
             throws IOException {

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -41,6 +41,7 @@
     <property name="hibernate.search.default.indexBase">/tmp/oid_lucene</property>
     <property name="search.default.optimizer.operation_limit">1000</property>
     <property name="search.default.optimizer.transaction_limit">100</property>
+    <property name="search.lucene_version">LUCENE_CURRENT</property>
 
     <!-- Hibernate ID Gen Configuration -->
     <property name="id.new_generator_mappings">true</property>

--- a/src/test/java/net/krotscheck/api/oauth/factory/CredentialsFactoryTest.java
+++ b/src/test/java/net/krotscheck/api/oauth/factory/CredentialsFactoryTest.java
@@ -112,6 +112,7 @@ public final class CredentialsFactoryTest {
      * @see <a href="https://sourceforge.net/p/cobertura/bugs/92/">https://sourceforge.net/p/cobertura/bugs/92/</a>
      */
     @Test
+    @SuppressWarnings("unchecked")
     public void testGenericInterface() throws Exception {
         UUID clientId = UUID.randomUUID();
         Provider<ContainerRequest> provider =


### PR DESCRIPTION
- Hibernate logging now properly uses the slf4j bridge.
- Some checkstyle ignore rules were added.
- Lucene version was set.