### PR TITLE
Revert "Collapse all the codestyle checks into one script run. (#73)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,12 @@ cache:
   directories:
   - $HOME/.m2
 before_script:
-  - mvn checkstyle:check cobertura:check pmd:check pmd:cpd-check
+  - mvn clean
+  - mvn checkstyle:check
+  - mvn cobertura:check
+  - mvn pmd:check
+  - mvn pmd:cpd-check
 script:
   - mvn install
 after_success:
-  - mvn cobertura:cobertura coveralls:report
+  - mvn clean cobertura:cobertura coveralls:report


### PR DESCRIPTION
This reverts commit 82218ca09cd36332fbb9f0586d6cb25bd8b7675e.

It seems that when you run a lot of java tools in one command, it very quickly exhausts the available memory on the VM. This splits them apart again.