### PR TITLE
Annotate entities with cache information

### DIFF
--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/Application.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/Application.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.annotations.ApiModelProperty;
 import net.krotscheck.kangaroo.common.hibernate.id.AbstractEntityReferenceDeserializer;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.SortNatural;
@@ -38,6 +40,7 @@ import org.hibernate.search.annotations.IndexedEmbedded;
 import org.hibernate.search.annotations.Store;
 
 import javax.persistence.Basic;
+import javax.persistence.Cacheable;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -60,6 +63,8 @@ import java.util.TreeMap;
  * @author Michael Krotscheck
  */
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "applications")
 @Indexed(index = "applications")
 @Analyzer(definition = "entity_analyzer")

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/ApplicationScope.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/ApplicationScope.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.annotations.ApiModelProperty;
 import net.krotscheck.kangaroo.common.hibernate.id.AbstractEntityReferenceDeserializer;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.search.annotations.Analyze;
 import org.hibernate.search.annotations.Analyzer;
 import org.hibernate.search.annotations.Field;
@@ -34,6 +36,7 @@ import org.hibernate.search.annotations.IndexedEmbedded;
 import org.hibernate.search.annotations.Store;
 
 import javax.persistence.Basic;
+import javax.persistence.Cacheable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -52,6 +55,8 @@ import java.util.List;
  * @author Michael Krotscheck
  */
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "application_scopes")
 @Indexed(index = "application_scopes")
 @Analyzer(definition = "entity_analyzer")

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/Authenticator.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/Authenticator.java
@@ -28,6 +28,8 @@ import io.swagger.annotations.ApiModelProperty;
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
 import net.krotscheck.kangaroo.authz.common.database.jackson.Views;
 import net.krotscheck.kangaroo.common.hibernate.id.AbstractEntityReferenceDeserializer;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.search.annotations.Analyze;
@@ -40,6 +42,7 @@ import org.hibernate.search.annotations.IndexedEmbedded;
 import org.hibernate.search.annotations.Store;
 import org.hibernate.search.bridge.builtin.EnumBridge;
 
+import javax.persistence.Cacheable;
 import javax.persistence.CascadeType;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
@@ -67,6 +70,8 @@ import java.util.Map;
  * @author Michael Krotscheck
  */
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "authenticators")
 @Indexed(index = "authenticators")
 @Analyzer(definition = "entity_analyzer")

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/Client.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/Client.java
@@ -26,6 +26,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Strings;
 import io.swagger.annotations.ApiModelProperty;
 import net.krotscheck.kangaroo.common.hibernate.id.AbstractEntityReferenceDeserializer;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.search.annotations.Analyze;
@@ -38,6 +40,7 @@ import org.hibernate.search.annotations.IndexedEmbedded;
 import org.hibernate.search.annotations.Store;
 
 import javax.persistence.Basic;
+import javax.persistence.Cacheable;
 import javax.persistence.CascadeType;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
@@ -69,6 +72,8 @@ import java.util.TreeMap;
  * @author Michael Krotscheck
  */
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "clients")
 @Indexed(index = "clients")
 @Analyzer(definition = "entity_analyzer")

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/ClientRedirect.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/ClientRedirect.java
@@ -18,8 +18,11 @@
 
 package net.krotscheck.kangaroo.authz.common.database.entity;
 
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.search.annotations.Indexed;
 
+import javax.persistence.Cacheable;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 
@@ -29,6 +32,8 @@ import javax.persistence.Table;
  * @author Michael Krotscheck
  */
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "client_redirects")
 @Indexed(index = "client_redirects")
 public final class ClientRedirect extends AbstractClientUri {

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/ClientReferrer.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/ClientReferrer.java
@@ -18,8 +18,11 @@
 
 package net.krotscheck.kangaroo.authz.common.database.entity;
 
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.search.annotations.Indexed;
 
+import javax.persistence.Cacheable;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 
@@ -29,6 +32,8 @@ import javax.persistence.Table;
  * @author Michael Krotscheck
  */
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "client_referrers")
 @Indexed(index = "client_referrers")
 public final class ClientReferrer extends AbstractClientUri {

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/HttpSession.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/HttpSession.java
@@ -20,8 +20,11 @@ package net.krotscheck.kangaroo.authz.common.database.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import net.krotscheck.kangaroo.common.hibernate.entity.AbstractEntity;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 import javax.persistence.Basic;
+import javax.persistence.Cacheable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -38,6 +41,8 @@ import java.util.List;
  * @author Michael Krotscheck
  */
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "http_sessions")
 public final class HttpSession extends AbstractEntity {
 

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/OAuthToken.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/OAuthToken.java
@@ -26,6 +26,8 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.annotations.ApiModelProperty;
 import net.krotscheck.kangaroo.common.hibernate.id.AbstractEntityReferenceDeserializer;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.SortNatural;
@@ -41,6 +43,7 @@ import org.hibernate.search.annotations.Store;
 import org.hibernate.search.bridge.builtin.EnumBridge;
 
 import javax.persistence.Basic;
+import javax.persistence.Cacheable;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -67,6 +70,8 @@ import java.util.TreeMap;
  * @author Michael Krotscheck
  */
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "oauth_tokens")
 @Indexed(index = "oauth_tokens")
 @Analyzer(definition = "entity_analyzer")

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/Role.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/Role.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.annotations.ApiModelProperty;
 import net.krotscheck.kangaroo.common.hibernate.id.AbstractEntityReferenceDeserializer;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.SortNatural;
 import org.hibernate.search.annotations.Analyze;
 import org.hibernate.search.annotations.Analyzer;
@@ -36,6 +38,7 @@ import org.hibernate.search.annotations.IndexedEmbedded;
 import org.hibernate.search.annotations.Store;
 
 import javax.persistence.Basic;
+import javax.persistence.Cacheable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -61,6 +64,8 @@ import java.util.TreeMap;
  * @author Michael Krotscheck
  */
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "roles")
 @Indexed(index = "roles")
 @Analyzer(definition = "entity_analyzer")

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/User.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/User.java
@@ -25,12 +25,15 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.annotations.ApiModelProperty;
 import net.krotscheck.kangaroo.common.hibernate.id.AbstractEntityReferenceDeserializer;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.search.annotations.Analyzer;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.IndexedEmbedded;
 
+import javax.persistence.Cacheable;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -48,6 +51,8 @@ import java.util.List;
  * @author Michael Krotscheck
  */
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "users")
 @Indexed(index = "users")
 @Analyzer(definition = "entity_analyzer")

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/UserIdentity.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/UserIdentity.java
@@ -28,6 +28,8 @@ import io.swagger.annotations.ApiModelProperty;
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
 import net.krotscheck.kangaroo.authz.common.database.jackson.Views;
 import net.krotscheck.kangaroo.common.hibernate.id.AbstractEntityReferenceDeserializer;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.search.annotations.Analyze;
@@ -42,6 +44,7 @@ import org.hibernate.search.annotations.Store;
 import org.hibernate.search.bridge.builtin.EnumBridge;
 
 import javax.persistence.Basic;
+import javax.persistence.Cacheable;
 import javax.persistence.CascadeType;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
@@ -70,6 +73,8 @@ import java.util.Map;
  * @author Michael Krotscheck
  */
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Indexed(index = "user_identities")
 @Table(name = "user_identities")
 @Analyzer(definition = "entity_analyzer")


### PR DESCRIPTION
In case a hibernate cache is configured, we add the cacheable
annotations and some basic strategies to the entities we use.